### PR TITLE
Add EOL at the end of SDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Membrane Protocol SDP
 
 [![Hex.pm](https://img.shields.io/hexpm/v/membrane_protocol_sdp.svg)](https://hex.pm/packages/membrane_protocol_sdp)
+[![API Docs](https://img.shields.io/badge/api-docs-yellow.svg?style=flat)](https://hexdocs.pm/membrane_protocol_sdp/)
 [![CircleCI](https://circleci.com/gh/membraneframework/membrane-protocol-sdp.svg?style=svg)](https://circleci.com/gh/membraneframework/membrane-protocol-sdp)
 
 Parser and serializer for Session Description Protocol. Based on [RFC4566](https://tools.ietf.org/html/rfc4566)

--- a/lib/sdp/serializer.ex
+++ b/lib/sdp/serializer.ex
@@ -34,8 +34,9 @@ defimpl Membrane.Protocol.SDP.Serializer, for: Membrane.Protocol.SDP do
     ]
     |> Enum.map(&Map.get(session, &1))
     |> Enum.reject(&(&1 == [] or &1 == nil))
-    |> Enum.map_join(@preffered_eol, &serialize_field/1)
-    |> (&(&1 <> @preffered_eol)).()
+    |> Enum.map(&serialize_field/1)
+    |> Enum.map(&(&1 <> @preferred_eol))
+    |> Enum.join()
   end
 
   defp serialize_field([%Timezone{} | _rest] = adjustments), do: Serializer.serialize(adjustments)

--- a/lib/sdp/serializer.ex
+++ b/lib/sdp/serializer.ex
@@ -10,7 +10,7 @@ defprotocol Membrane.Protocol.SDP.Serializer do
 end
 
 defimpl Membrane.Protocol.SDP.Serializer, for: Membrane.Protocol.SDP do
-  @preffered_eol "\r\n"
+  @preferred_eol "\r\n"
 
   alias Membrane.Protocol.SDP.{Serializer, Timezone}
 
@@ -42,7 +42,7 @@ defimpl Membrane.Protocol.SDP.Serializer, for: Membrane.Protocol.SDP do
   defp serialize_field([%Timezone{} | _rest] = adjustments), do: Serializer.serialize(adjustments)
 
   defp serialize_field(list) when is_list(list),
-    do: Enum.map_join(list, @preffered_eol, &Serializer.serialize/1)
+    do: Enum.map_join(list, @preferred_eol, &Serializer.serialize/1)
 
   defp serialize_field(value), do: Serializer.serialize(value)
 end

--- a/lib/sdp/serializer.ex
+++ b/lib/sdp/serializer.ex
@@ -35,6 +35,7 @@ defimpl Membrane.Protocol.SDP.Serializer, for: Membrane.Protocol.SDP do
     |> Enum.map(&Map.get(session, &1))
     |> Enum.reject(&(&1 == [] or &1 == nil))
     |> Enum.map_join(@preffered_eol, &serialize_field/1)
+    |> (&(&1 <> @preffered_eol)).()
   end
 
   defp serialize_field([%Timezone{} | _rest] = adjustments), do: Serializer.serialize(adjustments)

--- a/test/rfc_spec_test.exs
+++ b/test/rfc_spec_test.exs
@@ -346,7 +346,6 @@ defmodule Membrane.Protocol.SDP.RFCTest do
         a=rtpmap:99 h263-1998/90000
         """
         |> String.replace("\n", "\r\n")
-        |> String.trim()
 
       assert expected ==
                SDP.serialize(%SDP{
@@ -425,7 +424,6 @@ defmodule Membrane.Protocol.SDP.RFCTest do
         a=rtpmap:32 MPV/90000
         """
         |> String.replace("\n", "\r\n")
-        |> String.trim()
 
       assert expected ==
                SDP.serialize(%SDP{
@@ -535,7 +533,6 @@ defmodule Membrane.Protocol.SDP.RFCTest do
         a=rtpmap:32 MPV/90000
         """
         |> String.replace("\n", "\r\n")
-        |> String.trim()
 
       assert expected ==
                SDP.serialize(%SDP{


### PR DESCRIPTION
According to 
```
The sequence CRLF (0x0d0a) is used to end a record, although parsers SHOULD be
tolerant and also accept records terminated with a single newline character
```

we should append EOL at the end of serialized SDP. Without this browser doesn't accept provided SDP with `invalid SDP line` error.