### PR TITLE
Adjustments for usage in WebRTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,88 +55,69 @@ a=rtpmap:99 h263-1998/90000
 # =>
 {:ok,
  %ExSDP{
-   attributes: [
-     %ExSDP.Attribute{key: "key", value: "value"},
-     %ExSDP.Attribute{key: nil, value: :recvonly}
-   ],
+   attributes: [{"key", "value"}, :recvonly],
    bandwidth: [%ExSDP.Bandwidth{bandwidth: 256, type: :AS}],
    connection_data: %ExSDP.ConnectionData{
-     addresses: [
-       %ExSDP.ConnectionData.IP4{
-         ttl: 127,
-         value: {224, 2, 17, 12}
-       }
-     ],
-     network_type: "IN"
+     address: {224, 2, 17, 12},
+     address_count: nil,
+     network_type: "IN",
+     ttl: 127
    },
-   email: %ExSDP.Email{value: "j.doe@example.com (Jane Doe)"},
+   email: "j.doe@example.com (Jane Doe)",
    encryption: %ExSDP.Encryption{key: "key", method: :clear},
    media: [
      %ExSDP.Media{
        attributes: [],
        bandwidth: [%ExSDP.Bandwidth{bandwidth: 256, type: :AS}],
        connection_data: %ExSDP.ConnectionData{
-         addresses: [
-           %ExSDP.ConnectionData.IP4{
-             ttl: 127,
-             value: {224, 2, 17, 12}
-           }
-         ],
-         network_type: "IN"
+         address: {224, 2, 17, 12},
+         address_count: nil,
+         network_type: "IN",
+         ttl: 127
        },
        encryption: %ExSDP.Encryption{key: nil, method: :prompt},
        fmt: [0],
-       ports: [49170],
+       port: 49170,
+       port_count: 1,
        protocol: "RTP/AVP",
        title: "Sample media title",
        type: :audio
      },
      %ExSDP.Media{
        attributes: [
-         %ExSDP.Attribute{
-           key: :rtpmap,
-           value: %ExSDP.Attribute.RTPMapping{
-             clock_rate: 90000,
-             encoding: "h263-1998",
-             params: nil,
-             payload_type: 99
-           }
+         %ExSDP.Attribute.RTPMapping{
+           clock_rate: 90000,
+           encoding: "h263-1998",
+           params: nil,
+           payload_type: 99
          }
        ],
        bandwidth: [%ExSDP.Bandwidth{bandwidth: 256, type: :AS}],
        connection_data: %ExSDP.ConnectionData{
-         addresses: [
-           %ExSDP.ConnectionData.IP4{
-             ttl: 127,
-             value: {224, 2, 17, 12}
-           }
-         ],
-         network_type: "IN"
+         address: {224, 2, 17, 12},
+         address_count: nil,
+         network_type: "IN",
+         ttl: 127
        },
        encryption: %ExSDP.Encryption{key: "key", method: :clear},
        fmt: 'c',
-       ports: [51372],
+       port: 51372,
+       port_count: 1,
        protocol: "RTP/AVP",
        title: nil,
        type: :video
      }
    ],
    origin: %ExSDP.Origin{
-     address: %ExSDP.ConnectionData.IP4{
-       ttl: nil,
-       value: {10, 47, 16, 5}
-     },
-     session_id: "2890844526",
-     session_version: "2890842807",
+     address: {10, 47, 16, 5},
+     network_type: "IN",
+     session_id: 2890844526,
+     session_version: 2890842807,
      username: "jdoe"
    },
-   phone_number: %ExSDP.PhoneNumber{value: "111 111 111"},
-   session_information: %ExSDP.SessionInformation{
-     value: "A Seminar on the session description protocol"
-   },
-   session_name: %ExSDP.SessionName{
-     value: "Very fancy session name"
-   },
+   phone_number: "111 111 111",
+   session_information: "A Seminar on the session description protocol",
+   session_name: "Very fancy session name",
    time_repeats: [
      %ExSDP.RepeatTimes{
        active_duration: 3600,
@@ -151,24 +132,13 @@ a=rtpmap:99 h263-1998/90000
    ],
    time_zones_adjustments: %ExSDP.Timezone{
      corrections: [
-       %ExSDP.Timezone.Correction{
-         adjustment_time: 2882844526,
-         offset: -1
-       },
-       %ExSDP.Timezone.Correction{
-         adjustment_time: 2898848070,
-         offset: 0
-       }
+       %ExSDP.Timezone.Correction{adjustment_time: 2882844526, offset: -1},
+       %ExSDP.Timezone.Correction{adjustment_time: 2898848070, offset: 0}
      ]
    },
-   timing: %ExSDP.Timing{
-     start_time: 2873397496,
-     stop_time: 2873404696
-   },
-   uri: %ExSDP.URI{
-     value: "http://www.example.com/seminars/sdp.pdf"
-   },
-   version: %ExSDP.Version{value: 0}
+   timing: %ExSDP.Timing{start_time: 2873397496, stop_time: 2873404696},
+   uri: "http://www.example.com/seminars/sdp.pdf",
+   version: 0
  }}
 ```
 
@@ -178,88 +148,64 @@ Serializer serializes `ExSDP` struct to a string with `\r\n` terminated lines.
 
 ```elixir
 %ExSDP{
-   attributes: [
-     %ExSDP.Attribute{key: "key", value: "value"},
-     %ExSDP.Attribute{key: nil, value: :recvonly}
-   ],
+   attributes: [{"key", "value"}, :recvonly],
    bandwidth: [%ExSDP.Bandwidth{bandwidth: 256, type: :AS}],
    connection_data: %ExSDP.ConnectionData{
-     addresses: [
-       %ExSDP.ConnectionData.IP4{
-         ttl: 127,
-         value: {224, 2, 17, 12}
-       }
-     ],
-     network_type: "IN"
+     address: {224, 2, 17, 12},
+     network_type: "IN",
+     ttl: 127
    },
-   email: %ExSDP.Email{value: "j.doe@example.com (Jane Doe)"},
+   email: "j.doe@example.com (Jane Doe)",
    encryption: %ExSDP.Encryption{key: "key", method: :clear},
    media: [
      %ExSDP.Media{
        attributes: [],
        bandwidth: [%ExSDP.Bandwidth{bandwidth: 256, type: :AS}],
        connection_data: %ExSDP.ConnectionData{
-         addresses: [
-           %ExSDP.ConnectionData.IP4{
-             ttl: 127,
-             value: {224, 2, 17, 12}
-           }
-         ],
-         network_type: "IN"
+         address: {224, 2, 17, 12},
+         network_type: "IN",
+         ttl: 127
        },
-       encryption: %ExSDP.Encryption{key: nil, method: :prompt},
+       encryption: %ExSDP.Encryption{method: :prompt},
        fmt: [0],
-       ports: [49170],
+       port: 49170,
+       port_count: 1,
        protocol: "RTP/AVP",
        title: "Sample media title",
        type: :audio
      },
      %ExSDP.Media{
        attributes: [
-         %ExSDP.Attribute{
-           key: :rtpmap,
-           value: %ExSDP.Attribute.RTPMapping{
-             clock_rate: 90000,
-             encoding: "h263-1998",
-             params: nil,
-             payload_type: 99
-           }
+         %ExSDP.Attribute.RTPMapping{
+           clock_rate: 90000,
+           encoding: "h263-1998",
+           payload_type: 99
          }
        ],
        bandwidth: [%ExSDP.Bandwidth{bandwidth: 256, type: :AS}],
        connection_data: %ExSDP.ConnectionData{
-         addresses: [
-           %ExSDP.ConnectionData.IP4{
-             ttl: 127,
-             value: {224, 2, 17, 12}
-           }
-         ],
-         network_type: "IN"
+         address: {224, 2, 17, 12},
+         network_type: "IN",
+         ttl: 127
        },
        encryption: %ExSDP.Encryption{key: "key", method: :clear},
        fmt: 'c',
-       ports: [51372],
+       port: 51372,
+       port_count: 1,
        protocol: "RTP/AVP",
-       title: nil,
        type: :video
      }
    ],
    origin: %ExSDP.Origin{
-     address: %ExSDP.ConnectionData.IP4{
-       ttl: nil,
-       value: {10, 47, 16, 5}
-     },
-     session_id: "2890844526",
-     session_version: "2890842807",
+     address: {10, 47, 16, 5},
+     network_type: "IN",
+     session_id: 2890844526,
+     session_version: 2890842807,
      username: "jdoe"
    },
-   phone_number: %ExSDP.PhoneNumber{value: "111 111 111"},
-   session_information: %ExSDP.SessionInformation{
-     value: "A Seminar on the session description protocol"
-   },
-   session_name: %ExSDP.SessionName{
-     value: "Very fancy session name"
-   },
+   phone_number: "111 111 111",
+   session_information: "A Seminar on the session description protocol",
+   session_name: "Very fancy session name",
    time_repeats: [
      %ExSDP.RepeatTimes{
        active_duration: 3600,
@@ -274,27 +220,15 @@ Serializer serializes `ExSDP` struct to a string with `\r\n` terminated lines.
    ],
    time_zones_adjustments: %ExSDP.Timezone{
      corrections: [
-       %ExSDP.Timezone.Correction{
-         adjustment_time: 2882844526,
-         offset: -1
-       },
-       %ExSDP.Timezone.Correction{
-         adjustment_time: 2898848070,
-         offset: 0
-       }
+       %ExSDP.Timezone.Correction{adjustment_time: 2882844526, offset: -1},
+       %ExSDP.Timezone.Correction{adjustment_time: 2898848070, offset: 0}
      ]
    },
-   timing: %ExSDP.Timing{
-     start_time: 2873397496,
-     stop_time: 2873404696
-   },
-   uri: %ExSDP.URI{
-     value: "http://www.example.com/seminars/sdp.pdf"
-   },
-   version: %ExSDP.Version{value: 0}
+   timing: %ExSDP.Timing{start_time: 2873397496, stop_time: 2873404696},
+   uri: "http://www.example.com/seminars/sdp.pdf",
+   version: 0
 }
-|> ExSDP.serialize
-|> String.replace("\r\n", "\n")
+|> to_string()
 
 # =>
 """

--- a/lib/ex_sdp.ex
+++ b/lib/ex_sdp.ex
@@ -31,6 +31,7 @@ defmodule ExSDP do
 
   alias ExSDP.{
     Attribute,
+    Address,
     Bandwidth,
     ConnectionData,
     Encryption,
@@ -69,15 +70,25 @@ defmodule ExSDP do
 
   By default:
   * `version` is `0`
-  * `origin` is generated with `ExSDP.Origin.new/1`
+  * `username`, `session_id`, `session_version` and `address` - refer to `Origin.new/1`
   * `session_name` is `-`
   """
-  @spec new(origin :: Origin.t(), version: non_neg_integer(), session_name: binary()) :: t()
-  def new(origin \\ Origin.new(), opts \\ []) do
+  @spec new(
+          version: non_neg_integer(),
+          username: binary(),
+          session_id: integer(),
+          session_version: integer(),
+          address: Address.t(),
+          session_name: binary()
+        ) :: t()
+  def new(opts \\ []) do
+    {version, opts} = Keyword.pop(opts, :version, 0)
+    {session_name, opts} = Keyword.pop(opts, :session_name, "-")
+
     %__MODULE__{
-      version: Keyword.get(opts, :version, 0),
-      origin: origin,
-      session_name: Keyword.get(opts, :session_name, "-")
+      version: version,
+      origin: Origin.new(opts),
+      session_name: session_name
     }
   end
 

--- a/lib/ex_sdp.ex
+++ b/lib/ex_sdp.ex
@@ -69,10 +69,11 @@ defmodule ExSDP do
 
   By default:
   * `version` is `0`
+  * `origin` is generated with `ExSDP.Origin.new/1`
   * `session_name` is `-`
   """
-  @spec new(origin :: binary(), version: non_neg_integer(), session_name: binary()) :: t()
-  def new(origin, opts \\ []) do
+  @spec new(origin :: Origin.t(), version: non_neg_integer(), session_name: binary()) :: t()
+  def new(origin \\ Origin.new(), opts \\ []) do
     %__MODULE__{
       version: Keyword.get(opts, :version, 0),
       origin: origin,

--- a/lib/ex_sdp.ex
+++ b/lib/ex_sdp.ex
@@ -85,8 +85,11 @@ defmodule ExSDP do
   def add_media(sdp, media), do: Map.update!(sdp, :media, &(&1 ++ Bunch.listify(media)))
 
   @spec add_attribute(sdp :: t(), attribute :: Attribute.t()) :: t()
-  def add_attribute(sdp, attribute),
-    do: Map.update!(sdp, :attributes, &(&1 ++ Bunch.listify(attribute)))
+  def add_attribute(sdp, attribute), do: add_attributes(sdp, [attribute])
+
+  @spec add_attributes(sdp :: t(), attributes :: [Attribute.t()]) :: t()
+  def add_attributes(sdp, attributes) when is_list(attributes),
+    do: Map.update!(sdp, :attributes, &(&1 ++ attributes))
 end
 
 defimpl String.Chars, for: ExSDP do

--- a/lib/ex_sdp/address.ex
+++ b/lib/ex_sdp/address.ex
@@ -1,0 +1,34 @@
+defmodule ExSDP.Address do
+  @moduledoc """
+  Module representing address used in connection-data and origin.
+  """
+
+  @type fqdn() :: {:IP4 | :IP6, binary()}
+  @type t() :: :inet.ip_address() | fqdn()
+
+  @spec parse_address(binary()) :: {:ok, t()} | {:error, :invalid_address}
+  def parse_address(address) do
+    case address |> to_charlist() |> :inet.parse_address() do
+      {:ok, address} -> {:ok, address}
+      # for fqdn
+      {:error, :einval} -> {:ok, address}
+      {:error, _} -> {:error, :invalid_address}
+    end
+  end
+
+  @spec parse_addrtype(binary()) :: {:ok, :IP4 | :IP6} | {:error, :invalid_addrtype}
+  def parse_addrtype("IP4" = addrtype), do: {:ok, String.to_atom(addrtype)}
+  def parse_addrtype("IP6" = addrtype), do: {:ok, String.to_atom(addrtype)}
+  def parse_addrtype(_addrtype), do: {:error, :invalid_addrtype}
+
+  @spec serialize_address(t()) :: binary()
+  def serialize_address({addrtype, fqdn}) when addrtype in [:IP4, :IP6] and is_binary(fqdn),
+    do: fqdn
+
+  def serialize_address(address), do: :inet.ntoa(address)
+
+  @spec get_addrtype(t()) :: :IP4 | :IP6
+  def get_addrtype({_a, _b, _c, _d}), do: :IP4
+  def get_addrtype({_a, _b, _c, _d, _e, _f, _g, _h}), do: :IP6
+  def get_addrtype({addrtype, _fqdn}) when addrtype in [:IP4, :IP6], do: addrtype
+end

--- a/lib/ex_sdp/address.ex
+++ b/lib/ex_sdp/address.ex
@@ -12,7 +12,6 @@ defmodule ExSDP.Address do
       {:ok, address} -> {:ok, address}
       # for fqdn
       {:error, :einval} -> {:ok, address}
-      {:error, _} -> {:error, :invalid_address}
     end
   end
 

--- a/lib/ex_sdp/attribute.ex
+++ b/lib/ex_sdp/attribute.ex
@@ -5,7 +5,7 @@ defmodule ExSDP.Attribute do
   use Bunch.Typespec
   use Bunch.Access
 
-  alias __MODULE__.RTPMapping
+  alias __MODULE__.{RTPMapping, Msid}
 
   @list_type flag_attributes :: [:recvonly, :sendrecv, :sendonly, :inactive]
   @list_type value_attributes :: [
@@ -53,6 +53,8 @@ defmodule ExSDP.Attribute do
   defp do_parse(flag, nil, _opts), do: {:ok, flag}
 
   defp do_parse("rtpmap", value, opts), do: RTPMapping.parse(value, opts)
+
+  defp do_parse("msid", value, _opts), do: Msid.parse(value)
 
   defp do_parse("framerate", value, _opts) do
     case String.split(value, "/") do

--- a/lib/ex_sdp/attribute.ex
+++ b/lib/ex_sdp/attribute.ex
@@ -12,6 +12,7 @@ defmodule ExSDP.Attribute do
   @type orient_value :: :portrait | :landscape | :seascape
   @type type_value :: :broadcast | :meeting | :moderated | :test | :H332
   @type framerate_value :: float() | {integer(), integer()}
+  @type group_semantic :: :BUNDLE
 
   @list_type flag_attributes :: [
                :recvonly,
@@ -40,6 +41,7 @@ defmodule ExSDP.Attribute do
   @type fingerprint :: {:fingerprint, {hash_function(), binary()}}
   @type setup :: {:setup, setup_value()}
   @type mid :: {:mid, binary()}
+  @type group :: {:group, {group_semantic(), [binary()]}}
 
   @type t ::
           __MODULE__.RTPMapping.t()
@@ -103,6 +105,7 @@ defmodule ExSDP.Attribute do
   defp do_parse("mid", value, _opts), do: {:ok, {:mid, value}}
   defp do_parse("rtcp-mux", value, _opts), do: {:ok, {:rtcp_mux, value}}
   defp do_parse("rtcp-rsize", value, _opts), do: {:ok, {:rtcp_rsize, value}}
+  defp do_parse("group", value, _opts), do: parse_group(value)
 
   defp do_parse(attribute, value, _opts) when attribute in ["maxptime", "ptime", "quality"] do
     case Integer.parse(value) do
@@ -161,6 +164,13 @@ defmodule ExSDP.Attribute do
       "actpass" -> {:ok, {:setup, :actpass}}
       "holdconn" -> {:ok, {:setup, :holdconn}}
       _ -> {:error, :invalid_setup}
+    end
+  end
+
+  defp parse_group(group) do
+    case String.split(group, " ") do
+      ["BUNDLE" | ids] -> {:ok, {:group, {:BUNDLE, ids}}}
+      _ -> {:error, :invalid_group}
     end
   end
 end

--- a/lib/ex_sdp/attribute.ex
+++ b/lib/ex_sdp/attribute.ex
@@ -45,6 +45,7 @@ defmodule ExSDP.Attribute do
           __MODULE__.RTPMapping.t()
           | __MODULE__.Msid.t()
           | __MODULE__.Fmtp.t()
+          | __MODULE__.Ssrc.t()
           | cat()
           | charset()
           | keywds()
@@ -82,11 +83,6 @@ defmodule ExSDP.Attribute do
     do_parse(attribute, List.first(value), opts)
   end
 
-  defp do_parse(flag, nil, _opts) when flag in @flag_attributes_strings,
-    do: {:ok, String.to_atom(flag)}
-
-  defp do_parse(flag, nil, _opts), do: {:ok, flag}
-
   defp do_parse("rtpmap", value, opts), do: RTPMapping.parse(value, opts)
   defp do_parse("msid", value, _opts), do: Msid.parse(value)
   defp do_parse("fmtp", value, _opts), do: Fmtp.parse(value)
@@ -114,6 +110,11 @@ defmodule ExSDP.Attribute do
       _ -> {:error, :invalid_attribute}
     end
   end
+
+  defp do_parse(flag, nil, _opts) when flag in @flag_attributes_strings,
+    do: {:ok, String.to_atom(flag)}
+
+  defp do_parse(flag, nil, _opts), do: {:ok, flag}
 
   defp do_parse(attribute, value, _opts), do: {:ok, {attribute, value}}
 

--- a/lib/ex_sdp/attribute.ex
+++ b/lib/ex_sdp/attribute.ex
@@ -5,7 +5,7 @@ defmodule ExSDP.Attribute do
   use Bunch.Typespec
   use Bunch.Access
 
-  alias __MODULE__.{RTPMapping, Msid}
+  alias __MODULE__.{RTPMapping, Msid, Fmtp}
 
   @list_type flag_attributes :: [:recvonly, :sendrecv, :sendonly, :inactive]
   @list_type value_attributes :: [
@@ -55,6 +55,8 @@ defmodule ExSDP.Attribute do
   defp do_parse("rtpmap", value, opts), do: RTPMapping.parse(value, opts)
 
   defp do_parse("msid", value, _opts), do: Msid.parse(value)
+
+  defp do_parse("fmtp", value, _opts), do: Fmtp.parse(value)
 
   defp do_parse("framerate", value, _opts) do
     case String.split(value, "/") do

--- a/lib/ex_sdp/attribute.ex
+++ b/lib/ex_sdp/attribute.ex
@@ -5,7 +5,7 @@ defmodule ExSDP.Attribute do
   use Bunch.Typespec
   use Bunch.Access
 
-  alias __MODULE__.{RTPMapping, Msid, Fmtp, Ssrc}
+  alias __MODULE__.{RTPMapping, MSID, FMTP, SSRC}
 
   @type hash_function :: :sha1 | :sha224 | :sha256 | :sha384 | :sha512
   @type setup_value :: :active | :passive | :actpass | :holdconn
@@ -45,9 +45,9 @@ defmodule ExSDP.Attribute do
 
   @type t ::
           __MODULE__.RTPMapping.t()
-          | __MODULE__.Msid.t()
-          | __MODULE__.Fmtp.t()
-          | __MODULE__.Ssrc.t()
+          | __MODULE__.MSID.t()
+          | __MODULE__.FMTP.t()
+          | __MODULE__.SSRC.t()
           | cat()
           | charset()
           | keywds()
@@ -87,9 +87,9 @@ defmodule ExSDP.Attribute do
   end
 
   defp do_parse("rtpmap", value, opts), do: RTPMapping.parse(value, opts)
-  defp do_parse("msid", value, _opts), do: Msid.parse(value)
-  defp do_parse("fmtp", value, _opts), do: Fmtp.parse(value)
-  defp do_parse("ssrc", value, _opts), do: Ssrc.parse(value)
+  defp do_parse("msid", value, _opts), do: MSID.parse(value)
+  defp do_parse("fmtp", value, _opts), do: FMTP.parse(value)
+  defp do_parse("ssrc", value, _opts), do: SSRC.parse(value)
   defp do_parse("cat", value, _opts), do: {:ok, {:cat, value}}
   defp do_parse("charset", value, _opts), do: {:ok, {:charset, value}}
   defp do_parse("keywds", value, _opts), do: {:ok, {:keywds, value}}

--- a/lib/ex_sdp/attribute.ex
+++ b/lib/ex_sdp/attribute.ex
@@ -7,29 +7,65 @@ defmodule ExSDP.Attribute do
 
   alias __MODULE__.{RTPMapping, Msid, Fmtp}
 
-  @list_type flag_attributes :: [:recvonly, :sendrecv, :sendonly, :inactive]
-  @list_type value_attributes :: [
-               :cat,
-               :charset,
-               :keywds,
-               :orient,
-               :lang,
-               :sdplang,
-               :tool,
-               :type,
-               :framerate,
-               :maxptime,
-               :ptime,
-               :quality
+  @type hash_function :: :sha1 | :sha224 | :sha256 | :sha384 | :sha512
+  @type setup_value :: :active | :passive | :actpass | :holdconn
+  @type orient_value :: :portrait | :landscape | :seascape
+  @type type_value :: :broadcast | :meeting | :moderated | :test | :H332
+  @type framerate_value :: float() | {integer(), integer()}
+
+  @list_type flag_attributes :: [
+               :recvonly,
+               :sendrecv,
+               :sendonly,
+               :inactive,
+               :rtcp_mux,
+               :rtcp_rsize
              ]
 
-  @flag_attributes_strings @flag_attributes |> Enum.map(&to_string/1)
-  @value_attributes_strings @value_attributes |> Enum.map(&to_string/1)
+  @type cat :: {:cat, binary()}
+  @type charset :: {:charset, binary()}
+  @type keywds :: {:keywds, binary()}
+  @type orient :: {:orient, orient_value()}
+  @type lang :: {:lang, binary()}
+  @type sdplang :: {:sdplang, binary()}
+  @type tool :: {:tool, binary()}
+  @type type :: {:type, type_value()}
+  @type framerate :: {:framerate, framerate_value()}
+  @type maxptime :: {:maxptime, non_neg_integer()}
+  @type ptime :: {:ptime, non_neg_integer()}
+  @type quality :: {:quality, non_neg_integer()}
+  @type ice_ufrag :: {:ice_ufrag, binary()}
+  @type ice_pwd :: {:ice_pwd, binary()}
+  @type ice_options :: {:ice_options, binary() | [binary()]}
+  @type fingerprint :: {:fingerprint, {hash_function(), binary()}}
+  @type setup :: {:setup, setup_value()}
+  @type mid :: {:mid, binary()}
 
-  @type framerate :: float() | {integer(), integer()}
-  @type key :: binary() | value_attributes()
-  @type value :: binary() | integer() | framerate() | flag_attributes()
-  @type t :: __MODULE__.RTPMapping.t() | {key(), value()} | flag_attributes() | binary()
+  @type t ::
+          __MODULE__.RTPMapping.t()
+          | __MODULE__.Msid.t()
+          | __MODULE__.Fmtp.t()
+          | cat()
+          | charset()
+          | keywds()
+          | orient()
+          | lang()
+          | sdplang()
+          | tool()
+          | type()
+          | framerate()
+          | maxptime()
+          | ptime()
+          | quality()
+          | ice_ufrag()
+          | ice_pwd()
+          | ice_options()
+          | fingerprint()
+          | setup()
+          | mid()
+          | flag_attributes()
+
+  @flag_attributes_strings @flag_attributes |> Enum.map(&to_string/1)
 
   @doc """
   Parses SDP Attribute line.
@@ -38,8 +74,7 @@ defmodule ExSDP.Attribute do
   `opts` is a keyword list that can contain some information for parsers.
 
   Unknown attributes keys are returned as strings, known ones as atoms.
-  Values for keys `:maxptime`, `:ptime` and `:quality` are converted into `integer()`.
-  Values for key `:framerate` is converted into `float()` or tuple of Integers.
+  For known attributes please refer to `t()`.
   """
   @spec parse(binary(), opts :: Keyword.t()) :: {:ok, t()} | {:error, atom()}
   def parse(line, opts \\ []) do
@@ -53,17 +88,25 @@ defmodule ExSDP.Attribute do
   defp do_parse(flag, nil, _opts), do: {:ok, flag}
 
   defp do_parse("rtpmap", value, opts), do: RTPMapping.parse(value, opts)
-
   defp do_parse("msid", value, _opts), do: Msid.parse(value)
-
   defp do_parse("fmtp", value, _opts), do: Fmtp.parse(value)
-
-  defp do_parse("framerate", value, _opts) do
-    case String.split(value, "/") do
-      [framerate] -> {:ok, {:framerate, String.to_float(framerate)}}
-      [left, right] -> {:ok, {:framerate, {String.to_integer(left), String.to_integer(right)}}}
-    end
-  end
+  defp do_parse("cat", value, _opts), do: {:ok, {:cat, value}}
+  defp do_parse("charset", value, _opts), do: {:ok, {:charset, value}}
+  defp do_parse("keywds", value, _opts), do: {:ok, {:keywds, value}}
+  defp do_parse("orient", value, _opts), do: parse_orient(value)
+  defp do_parse("lang", value, _opts), do: {:ok, {:lang, value}}
+  defp do_parse("sdplang", value, _opts), do: {:ok, {:sdplang, value}}
+  defp do_parse("tool", value, _opts), do: {:ok, {:tool, value}}
+  defp do_parse("type", value, _opts), do: parse_type(value)
+  defp do_parse("framerate", value, _opts), do: parse_framerate(value)
+  defp do_parse("ice-ufrag", value, _opts), do: {:ok, {:ice_ufrag, value}}
+  defp do_parse("ice-pwd", value, _opts), do: {:ok, {:ice_pwd, value}}
+  defp do_parse("ice-options", value, _opts), do: {:ok, {:ice_options, String.split(value, " ")}}
+  defp do_parse("fingerprint", value, _opts), do: parse_fingerprint(value)
+  defp do_parse("setup", value, _opts), do: parse_setup(value)
+  defp do_parse("mid", value, _opts), do: {:ok, {:mid, value}}
+  defp do_parse("rtcp-mux", value, _opts), do: {:ok, {:rtcp_mux, value}}
+  defp do_parse("rtcp-rsize", value, _opts), do: {:ok, {:rtcp_rsize, value}}
 
   defp do_parse(attribute, value, _opts) when attribute in ["maxptime", "ptime", "quality"] do
     case Integer.parse(value) do
@@ -72,8 +115,51 @@ defmodule ExSDP.Attribute do
     end
   end
 
-  defp do_parse(attribute, value, _opts) when attribute in @value_attributes_strings,
-    do: {:ok, {String.to_atom(attribute), value}}
-
   defp do_parse(attribute, value, _opts), do: {:ok, {attribute, value}}
+
+  defp parse_orient(orient) do
+    case orient do
+      string when string in ["portrait", "landscape", "seascape"] -> String.to_atom(string)
+      _ -> {:error, :invalid_orient}
+    end
+  end
+
+  defp parse_type(type) do
+    case type do
+      string when string in ["broadcast", "meeting", "moderated", "test", "H332"] ->
+        String.to_atom(string)
+
+      _ ->
+        {:error, :invalid_type}
+    end
+  end
+
+  defp parse_framerate(framerate) do
+    case String.split(framerate, "/") do
+      [value] -> {:ok, {:framerate, String.to_float(value)}}
+      [left, right] -> {:ok, {:framerate, {String.to_integer(left), String.to_integer(right)}}}
+      _ -> {:error, :invalid_framerate}
+    end
+  end
+
+  defp parse_fingerprint(fingerprint) do
+    case String.split(fingerprint, " ") do
+      ["sha-1", value] -> {:ok, {:fingerprint, {:sha1, value}}}
+      ["sha-224", value] -> {:ok, {:fingerprint, {:sha224, value}}}
+      ["sha-256", value] -> {:ok, {:fingerprint, {:sha256, value}}}
+      ["sha-384", value] -> {:ok, {:fingerprint, {:sha384, value}}}
+      ["sha-512", value] -> {:ok, {:fingerprint, {:sha512, value}}}
+      _ -> {:error, :invalid_fingerprint}
+    end
+  end
+
+  defp parse_setup(setup) do
+    case setup do
+      "active" -> {:ok, {:setup, :active}}
+      "passive" -> {:ok, {:setup, :passive}}
+      "actpass" -> {:ok, {:setup, :actpass}}
+      "holdconn" -> {:ok, {:setup, :holdconn}}
+      _ -> {:error, :invalid_setup}
+    end
+  end
 end

--- a/lib/ex_sdp/attribute.ex
+++ b/lib/ex_sdp/attribute.ex
@@ -5,7 +5,7 @@ defmodule ExSDP.Attribute do
   use Bunch.Typespec
   use Bunch.Access
 
-  alias __MODULE__.{RTPMapping, Msid, Fmtp}
+  alias __MODULE__.{RTPMapping, Msid, Fmtp, Ssrc}
 
   @type hash_function :: :sha1 | :sha224 | :sha256 | :sha384 | :sha512
   @type setup_value :: :active | :passive | :actpass | :holdconn
@@ -66,6 +66,7 @@ defmodule ExSDP.Attribute do
           | fingerprint()
           | setup()
           | mid()
+          | group()
           | flag_attributes()
 
   @flag_attributes_strings @flag_attributes |> Enum.map(&to_string/1)
@@ -88,6 +89,7 @@ defmodule ExSDP.Attribute do
   defp do_parse("rtpmap", value, opts), do: RTPMapping.parse(value, opts)
   defp do_parse("msid", value, _opts), do: Msid.parse(value)
   defp do_parse("fmtp", value, _opts), do: Fmtp.parse(value)
+  defp do_parse("ssrc", value, _opts), do: Ssrc.parse(value)
   defp do_parse("cat", value, _opts), do: {:ok, {:cat, value}}
   defp do_parse("charset", value, _opts), do: {:ok, {:charset, value}}
   defp do_parse("keywds", value, _opts), do: {:ok, {:keywds, value}}
@@ -103,8 +105,8 @@ defmodule ExSDP.Attribute do
   defp do_parse("fingerprint", value, _opts), do: parse_fingerprint(value)
   defp do_parse("setup", value, _opts), do: parse_setup(value)
   defp do_parse("mid", value, _opts), do: {:ok, {:mid, value}}
-  defp do_parse("rtcp-mux", value, _opts), do: {:ok, {:rtcp_mux, value}}
-  defp do_parse("rtcp-rsize", value, _opts), do: {:ok, {:rtcp_rsize, value}}
+  defp do_parse("rtcp-mux", _value, _opts), do: {:ok, :rtcp_mux}
+  defp do_parse("rtcp-rsize", _value, _opts), do: {:ok, :rtcp_rsize}
   defp do_parse("group", value, _opts), do: parse_group(value)
 
   defp do_parse(attribute, value, _opts) when attribute in ["maxptime", "ptime", "quality"] do

--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -27,6 +27,7 @@ defmodule ExSDP.Attribute.Fmtp do
                 :useinbandfec,
                 :usedtx,
                 # VP8/9
+                :profile_id,
                 :max_fr
               ]
 
@@ -48,6 +49,7 @@ defmodule ExSDP.Attribute.Fmtp do
           useinbandfec: boolean() | nil,
           usedtx: boolean() | nil,
           # VP8/9
+          profile_id: non_neg_integer() | nil,
           max_fr: non_neg_integer() | nil
         }
 
@@ -156,8 +158,12 @@ defmodule ExSDP.Attribute.Fmtp do
          do: {rest, %{fmtp | max_fr: value}}
   end
 
-  defp parse_param(_params, _fmtp),
-    do: {:error, :unsupported_parameter}
+  defp parse_param(["profile-id=" <> profile_id | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(profile_id),
+         do: {rest, %{fmtp | profile_id: value}}
+  end
+
+  defp parse_param(_params, _fmtp), do: {:error, :unsupported_parameter}
 end
 
 defimpl String.Chars, for: ExSDP.Attribute.Fmtp do
@@ -184,6 +190,7 @@ defimpl String.Chars, for: ExSDP.Attribute.Fmtp do
         Serializer.maybe_serialize("useinbandfec", fmtp.useinbandfec),
         Serializer.maybe_serialize("usedtx", fmtp.usedtx),
         # VP8/9
+        Serializer.maybe_serialize("profile-id", fmtp.profile_id),
         Serializer.maybe_serialize("max-fr", fmtp.max_fr)
       ]
       |> Enum.filter(fn param -> param != "" end)

--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -61,7 +61,7 @@ defmodule ExSDP.Attribute.Fmtp do
   """
   @type reason :: :unsupported_parameter | :string_nan | :string_not_hex | :string_not_0_nor_1
 
-  @spec parse(binary()) :: {:ok, t()} | {:error, {:invalid_fmtp, reason()}}
+  @spec parse(binary()) :: {:ok, t()} | {:error, reason()}
   def parse(fmtp) do
     [pt, rest] = String.split(fmtp, " ")
     fmtp = %__MODULE__{pt: String.to_integer(pt)}
@@ -74,7 +74,7 @@ defmodule ExSDP.Attribute.Fmtp do
   defp do_parse(params, fmtp) do
     case parse_param(params, fmtp) do
       {rest, %__MODULE__{} = fmtp} -> do_parse(rest, fmtp)
-      {:error, reason} -> {:error, {:invalid_fmtp, reason}}
+      {:error, _reason} = error -> error
     end
   end
 

--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -1,4 +1,4 @@
-defmodule ExSDP.Attribute.Fmtp do
+defmodule ExSDP.Attribute.FMTP do
   @moduledoc """
   This module represents fmtp (RFC 5576).
 
@@ -166,7 +166,7 @@ defmodule ExSDP.Attribute.Fmtp do
   defp parse_param(_params, _fmtp), do: {:error, :unsupported_parameter}
 end
 
-defimpl String.Chars, for: ExSDP.Attribute.Fmtp do
+defimpl String.Chars, for: ExSDP.Attribute.FMTP do
   def to_string(fmtp) do
     alias ExSDP.Serializer
 

--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -154,7 +154,7 @@ defmodule ExSDP.Attribute.Fmtp do
   end
 
   defp parse_param(["max-fr=" <> max_fr | rest], fmtp) do
-    with {:ok, value} <- Utils.parse_numeric_bool_string(max_fr),
+    with {:ok, value} <- Utils.parse_numeric_string(max_fr),
          do: {rest, %{fmtp | max_fr: value}}
   end
 

--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -1,0 +1,194 @@
+defmodule ExSDP.Attribute.Fmtp do
+  @moduledoc """
+  This module represents fmtp (RFC 5576).
+
+  Parameters for H264 (not all, RFC 6184), VP8, VP9 and OPUS (RFC 7587) are currently supported.
+  """
+  alias ExSDP.Utils
+
+  @enforce_keys [:pt]
+  defstruct @enforce_keys ++
+              [
+                # H264
+                :profile_level_id,
+                :level_asymmetry_allowed,
+                :packetization_mode,
+                :max_mbps,
+                :max_smbps,
+                :max_fs,
+                :max_dpb,
+                :max_br,
+                # OPUS
+                :maxaveragebitrate,
+                :maxplaybackrate,
+                :minptime,
+                :stereo,
+                :cbr,
+                :useinbandfec,
+                :usedtx,
+                # VP8/9
+                :max_fr
+              ]
+
+  @type t :: %__MODULE__{
+          profile_level_id: non_neg_integer() | nil,
+          max_mbps: non_neg_integer() | nil,
+          max_smbps: non_neg_integer() | nil,
+          max_fs: non_neg_integer() | nil,
+          max_dpb: non_neg_integer() | nil,
+          max_br: non_neg_integer() | nil,
+          level_asymmetry_allowed: boolean() | nil,
+          packetization_mode: non_neg_integer() | nil,
+          # OPUS
+          maxaveragebitrate: non_neg_integer() | nil,
+          maxplaybackrate: non_neg_integer() | nil,
+          minptime: non_neg_integer() | nil,
+          stereo: boolean() | nil,
+          cbr: boolean() | nil,
+          useinbandfec: boolean() | nil,
+          usedtx: boolean() | nil,
+          # VP8/9
+          max_fr: non_neg_integer() | nil
+        }
+
+  @typedoc """
+  Key that can be used for searching this attribute using `ExSDP.Media.get_attribute/2`.
+  """
+  @type attr_key :: :fmtp
+
+  @typedoc """
+  Reason of parsing failure.
+  """
+  @type reason :: :unsupported_parameter | :string_nan | :string_not_hex | :string_not_0_nor_1
+
+  @spec parse(binary()) :: {:ok, t()} | {:error, {:invalid_fmtp, reason()}}
+  def parse(fmtp) do
+    [pt, rest] = String.split(fmtp, " ")
+    fmtp = %__MODULE__{pt: String.to_integer(pt)}
+    params = String.split(rest, ";")
+    do_parse(params, fmtp)
+  end
+
+  defp do_parse([], fmtp), do: {:ok, fmtp}
+
+  defp do_parse(params, fmtp) do
+    case parse_param(params, fmtp) do
+      {rest, %__MODULE__{} = fmtp} -> do_parse(rest, fmtp)
+      {:error, reason} -> {:error, {:invalid_fmtp, reason}}
+    end
+  end
+
+  defp parse_param(["profile-level-id=" <> profile_level_id | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_hex_string(profile_level_id),
+         do: {rest, %{fmtp | profile_level_id: value}}
+  end
+
+  defp parse_param(["level-asymmetry-allowed=" <> level_asymmetry_allowed | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_bool_string(level_asymmetry_allowed),
+         do: {rest, %{fmtp | level_asymmetry_allowed: value}}
+  end
+
+  defp parse_param(["packetization-mode=" <> packetization_mode | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(packetization_mode),
+         do: {rest, %{fmtp | packetization_mode: value}}
+  end
+
+  defp parse_param(["max-mbps=" <> max_mbps | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(max_mbps),
+         do: {rest, %{fmtp | max_mbps: value}}
+  end
+
+  defp parse_param(["max-smbps=" <> max_smbps | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(max_smbps),
+         do: {rest, %{fmtp | max_smbps: value}}
+  end
+
+  defp parse_param(["max-fs=" <> max_fs | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(max_fs), do: {rest, %{fmtp | max_fs: value}}
+  end
+
+  defp parse_param(["max-dpb=" <> max_dpb | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(max_dpb),
+         do: {rest, %{fmtp | max_dpb: value}}
+  end
+
+  defp parse_param(["max-br=" <> max_br | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(max_br), do: {rest, %{fmtp | max_br: value}}
+  end
+
+  defp parse_param(["maxaveragebitrate=" <> maxaveragebitrate | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(maxaveragebitrate),
+         do: {rest, %{fmtp | maxaveragebitrate: value}}
+  end
+
+  defp parse_param(["maxplaybackrate=" <> maxplaybackrate | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(maxplaybackrate),
+         do: {rest, %{fmtp | maxplaybackrate: value}}
+  end
+
+  defp parse_param(["minptime=" <> minptime | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(minptime),
+         do: {rest, %{fmtp | minptime: value}}
+  end
+
+  defp parse_param(["stereo=" <> stereo | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_bool_string(stereo),
+         do: {rest, %{fmtp | stereo: value}}
+  end
+
+  defp parse_param(["cbr=" <> cbr | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_bool_string(cbr),
+         do: {rest, %{fmtp | cbr: value}}
+  end
+
+  defp parse_param(["useinbandfec=" <> useinbandfec | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_bool_string(useinbandfec),
+         do: {rest, %{fmtp | useinbandfec: value}}
+  end
+
+  defp parse_param(["usedtx=" <> usedtx | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_bool_string(usedtx),
+         do: {rest, %{fmtp | usedtx: value}}
+  end
+
+  defp parse_param(["max-fr=" <> max_fr | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_bool_string(max_fr),
+         do: {rest, %{fmtp | max_fr: value}}
+  end
+
+  defp parse_param(_params, _fmtp),
+    do: {:error, :unsupported_parameter}
+end
+
+defimpl String.Chars, for: ExSDP.Attribute.Fmtp do
+  def to_string(fmtp) do
+    alias ExSDP.Serializer
+
+    params =
+      [
+        # H264
+        Serializer.maybe_serialize_hex("profile-level-id", fmtp.profile_level_id),
+        Serializer.maybe_serialize("max-mbps", fmtp.max_mbps),
+        Serializer.maybe_serialize("max-smbps", fmtp.max_smbps),
+        Serializer.maybe_serialize("max-fs", fmtp.max_fs),
+        Serializer.maybe_serialize("max-dpb", fmtp.max_dpb),
+        Serializer.maybe_serialize("max-br", fmtp.max_br),
+        Serializer.maybe_serialize("level-asymmetry-allowed", fmtp.level_asymmetry_allowed),
+        Serializer.maybe_serialize("packetization-mode", fmtp.packetization_mode),
+        # OPUS
+        Serializer.maybe_serialize("maxaveragebitrate", fmtp.maxaveragebitrate),
+        Serializer.maybe_serialize("maxplaybackrate", fmtp.maxplaybackrate),
+        Serializer.maybe_serialize("minptime", fmtp.minptime),
+        Serializer.maybe_serialize("stereo", fmtp.stereo),
+        Serializer.maybe_serialize("cbr", fmtp.cbr),
+        Serializer.maybe_serialize("useinbandfec", fmtp.useinbandfec),
+        Serializer.maybe_serialize("usedtx", fmtp.usedtx),
+        # VP8/9
+        Serializer.maybe_serialize("max-fr", fmtp.max_fr)
+      ]
+      |> Enum.filter(fn param -> param != "" end)
+      |> Enum.join(";")
+
+    "fmtp:#{fmtp.pt} #{params}"
+  end
+end

--- a/lib/ex_sdp/attribute/msid.ex
+++ b/lib/ex_sdp/attribute/msid.ex
@@ -1,0 +1,62 @@
+defmodule ExSDP.Attribute.Msid do
+  @moduledoc """
+  This module represents msid (RFC 8830).
+  """
+
+  @enforce_keys [:id]
+  defstruct @enforce_keys ++ [:app_data]
+
+  @type t :: %__MODULE__{id: binary(), app_data: binary() | nil}
+
+  @spec new(id :: binary(), app_data :: binary() | nil) :: t()
+  def new(id \\ generate_random(), app_data \\ generate_random()) do
+    %__MODULE__{id: id, app_data: app_data}
+  end
+
+  @typedoc """
+  Key that can be used for searching this attribute using `ExSDP.Media.get_attribute/2`.
+  """
+  @type attr_key :: :msid
+
+  @doc """
+  Generates random, by default 36 char string that can be used as `id` or `app_data`.
+
+  String is built from letters `a-z` digits `0-9` and `-`.
+  Although this char set doesn't contain all possible chars it meets the requirements
+  described in RFC 8830.
+  """
+  @spec generate_random(length :: 1..64) :: binary()
+  def generate_random(length \\ 36) do
+    char_set = Enum.to_list(?a..?z) ++ Enum.to_list(?0..?9) ++ [?-]
+    for _ <- 1..length, into: "", do: <<Enum.random(char_set)>>
+  end
+
+  @spec parse(binary()) :: {:error, :invalid_msid} | {:ok, t()}
+  def parse(msid) do
+    case String.split(msid, " ") do
+      [""] ->
+        {:error, :invalid_msid}
+
+      ["", _app_data] ->
+        {:error, :invalid_msid}
+
+      [id] ->
+        {:ok, %__MODULE__{id: id}}
+
+      [id, app_data] ->
+        msid = %__MODULE__{
+          id: id,
+          app_data: app_data
+        }
+
+        {:ok, msid}
+    end
+  end
+end
+
+defimpl String.Chars, for: ExSDP.Attribute.Msid do
+  alias ExSDP.Attribute.Msid
+
+  def to_string(%Msid{id: id, app_data: nil}), do: "msid:#{id}"
+  def to_string(%Msid{id: id, app_data: app_data}), do: "msid:#{id} #{app_data}"
+end

--- a/lib/ex_sdp/attribute/msid.ex
+++ b/lib/ex_sdp/attribute/msid.ex
@@ -31,7 +31,7 @@ defmodule ExSDP.Attribute.Msid do
     for _ <- 1..length, into: "", do: <<Enum.random(char_set)>>
   end
 
-  @spec parse(binary()) :: {:error, :invalid_msid} | {:ok, t()}
+  @spec parse(binary()) :: {:ok, t()} | {:error, :invalid_msid}
   def parse(msid) do
     case String.split(msid, " ") do
       [""] ->
@@ -50,6 +50,9 @@ defmodule ExSDP.Attribute.Msid do
         }
 
         {:ok, msid}
+
+      _ ->
+        {:error, :invalid_msid}
     end
   end
 end

--- a/lib/ex_sdp/attribute/msid.ex
+++ b/lib/ex_sdp/attribute/msid.ex
@@ -1,4 +1,4 @@
-defmodule ExSDP.Attribute.Msid do
+defmodule ExSDP.Attribute.MSID do
   @moduledoc """
   This module represents msid (RFC 8830).
   """
@@ -44,9 +44,9 @@ defmodule ExSDP.Attribute.Msid do
   end
 end
 
-defimpl String.Chars, for: ExSDP.Attribute.Msid do
-  alias ExSDP.Attribute.Msid
+defimpl String.Chars, for: ExSDP.Attribute.MSID do
+  alias ExSDP.Attribute.MSID
 
-  def to_string(%Msid{id: id, app_data: nil}), do: "msid:#{id}"
-  def to_string(%Msid{id: id, app_data: app_data}), do: "msid:#{id} #{app_data}"
+  def to_string(%MSID{id: id, app_data: nil}), do: "msid:#{id}"
+  def to_string(%MSID{id: id, app_data: app_data}), do: "msid:#{id} #{app_data}"
 end

--- a/lib/ex_sdp/attribute/msid.ex
+++ b/lib/ex_sdp/attribute/msid.ex
@@ -8,27 +8,14 @@ defmodule ExSDP.Attribute.Msid do
 
   @type t :: %__MODULE__{id: binary(), app_data: binary() | nil}
 
-  @spec new(id :: binary(), app_data :: binary() | nil) :: t()
-  def new(id \\ generate_random(), app_data \\ generate_random()) do
-    %__MODULE__{id: id, app_data: app_data}
-  end
-
   @typedoc """
   Key that can be used for searching this attribute using `ExSDP.Media.get_attribute/2`.
   """
   @type attr_key :: :msid
 
-  @doc """
-  Generates random, by default 36 char string that can be used as `id` or `app_data`.
-
-  String is built from letters `a-z` digits `0-9` and `-`.
-  Although this char set doesn't contain all possible chars it meets the requirements
-  described in RFC 8830.
-  """
-  @spec generate_random(length :: 1..64) :: binary()
-  def generate_random(length \\ 36) do
-    char_set = Enum.to_list(?a..?z) ++ Enum.to_list(?0..?9) ++ [?-]
-    for _ <- 1..length, into: "", do: <<Enum.random(char_set)>>
+  @spec new(id :: binary(), app_data :: binary() | nil) :: t()
+  def new(id \\ UUID.uuid4(), app_data \\ UUID.uuid4()) do
+    %__MODULE__{id: id, app_data: app_data}
   end
 
   @spec parse(binary()) :: {:ok, t()} | {:error, :invalid_msid}

--- a/lib/ex_sdp/attribute/rtp_mapping.ex
+++ b/lib/ex_sdp/attribute/rtp_mapping.ex
@@ -22,7 +22,7 @@ defmodule ExSDP.Attribute.RTPMapping do
   @type attr_key :: :rtpmap
 
   @spec parse(binary(), opts :: []) ::
-          {:ok, t()} | {:error, :string_nan | :only_audio_can_have_params}
+          {:ok, t()} | {:error, :string_nan | :only_audio_can_have_params | :invalid_rtpmap}
   def parse(mapping, opts) do
     with [payload_type, encoding | _] <- String.split(mapping, " "),
          [encoding_name, clock_rate | params] <- String.split(encoding, "/"),
@@ -39,6 +39,7 @@ defmodule ExSDP.Attribute.RTPMapping do
       {:ok, mapping}
     else
       {:error, reason} -> {:error, reason}
+      _ -> {:error, :invalid_rtpmap}
     end
   end
 

--- a/lib/ex_sdp/attribute/rtp_mapping.ex
+++ b/lib/ex_sdp/attribute/rtp_mapping.ex
@@ -4,6 +4,8 @@ defmodule ExSDP.Attribute.RTPMapping do
   """
   use Bunch.Access
 
+  alias ExSDP.Utils
+
   @enforce_keys [:payload_type, :encoding, :clock_rate]
   defstruct @enforce_keys ++ [:params]
 
@@ -19,31 +21,31 @@ defmodule ExSDP.Attribute.RTPMapping do
   """
   @type attr_key :: :rtpmap
 
-  @spec parse(binary(), opts :: []) :: {:ok, t()} | {:error, :invalid_attribute | :invalid_param}
+  @spec parse(binary(), opts :: []) ::
+          {:ok, t()} | {:error, :string_nan | :only_audio_can_have_params}
   def parse(mapping, opts) do
     with [payload_type, encoding | _] <- String.split(mapping, " "),
          [encoding_name, clock_rate | params] <- String.split(encoding, "/"),
-         {payload_type, ""} <- Integer.parse(payload_type),
-         {clock_rate, ""} <- Integer.parse(clock_rate) do
+         {:ok, payload_type} <- Utils.parse_numeric_string(payload_type),
+         {:ok, clock_rate} <- Utils.parse_numeric_string(clock_rate),
+         {:ok, params} <- parse_params(params, opts) do
       mapping = %__MODULE__{
         payload_type: payload_type,
         encoding: encoding_name,
         clock_rate: clock_rate,
-        params: parse_params(params, opts)
+        params: params
       }
 
       {:ok, mapping}
     else
-      _ -> {:error, :invalid_attribute}
+      {:error, reason} -> {:error, reason}
     end
   end
 
-  defp parse_params([channels], media_type: :audio), do: String.to_integer(channels)
-  defp parse_params([], media_type: :audio), do: 1
-  defp parse_params([], media_type: _media_type), do: nil
-
-  defp parse_params(_params, media_type: _media_type),
-    do: raise("Only audio attributes can specify parameters")
+  defp parse_params([channels], media_type: :audio), do: {:ok, String.to_integer(channels)}
+  defp parse_params([], media_type: :audio), do: {:ok, 1}
+  defp parse_params([], media_type: _media_type), do: {:ok, nil}
+  defp parse_params(_params, media_type: _media_type), do: {:error, :only_audio_can_have_params}
 end
 
 defimpl String.Chars, for: ExSDP.Attribute.RTPMapping do

--- a/lib/ex_sdp/attribute/ssrc.ex
+++ b/lib/ex_sdp/attribute/ssrc.ex
@@ -2,6 +2,7 @@ defmodule ExSDP.Attribute.Ssrc do
   @moduledoc """
   This module represents ssrc (RFC 5576).
   """
+  alias ExSDP.Utils
 
   @enforce_keys [:id, :attribute]
   defstruct @enforce_keys ++ [:value]
@@ -15,16 +16,15 @@ defmodule ExSDP.Attribute.Ssrc do
 
   @spec parse(binary()) :: {:ok, t()} | {:error, :invalid_ssrc}
   def parse(ssrc) do
-    case String.split(ssrc, " ") do
-      [id, attribute] ->
-        case String.split(attribute, ":") do
-          [attribute, value] -> {:ok, %__MODULE__{id: id, attribute: attribute, value: value}}
-          [attribute] -> {:ok, %__MODULE__{id: id, attribute: attribute}}
-          _ -> {:error, :invalid_ssrc}
-        end
-
-      _ ->
-        {:error, :invalid_ssrc}
+    with [id, attribute] <- String.split(ssrc, " "),
+         {:ok, id} <- Utils.parse_numeric_string(id) do
+      case String.split(attribute, ":") do
+        [attribute, value] -> {:ok, %__MODULE__{id: id, attribute: attribute, value: value}}
+        [attribute] -> {:ok, %__MODULE__{id: id, attribute: attribute}}
+        _ -> {:error, :invalid_ssrc}
+      end
+    else
+      _ -> {:error, :invalid_ssrc}
     end
   end
 end

--- a/lib/ex_sdp/attribute/ssrc.ex
+++ b/lib/ex_sdp/attribute/ssrc.ex
@@ -1,0 +1,39 @@
+defmodule ExSDP.Attribute.Ssrc do
+  @moduledoc """
+  This module represents ssrc (RFC 5576).
+  """
+
+  @enforce_keys [:id, :attribute]
+  defstruct @enforce_keys ++ [:value]
+
+  @type t :: %__MODULE__{id: non_neg_integer(), attribute: binary(), value: binary() | nil}
+
+  @typedoc """
+  Key that can be used for searching this attribute using `ExSDP.Media.get_attribute/2`.
+  """
+  @type attr_key :: :ssrc
+
+  @spec parse(binary()) :: {:ok, t()} | {:error, :invalid_ssrc}
+  def parse(ssrc) do
+    case String.split(ssrc, " ") do
+      [id, attribute] ->
+        case String.split(attribute, ":") do
+          [attribute, value] -> {:ok, %__MODULE__{id: id, attribute: attribute, value: value}}
+          [attribute] -> {:ok, %__MODULE__{id: id, attribute: attribute}}
+          _ -> {:error, :invalid_ssrc}
+        end
+
+      _ ->
+        {:error, :invalid_ssrc}
+    end
+  end
+end
+
+defimpl String.Chars, for: ExSDP.Attribute.Ssrc do
+  alias ExSDP.Attribute.Ssrc
+
+  def to_string(%Ssrc{id: id, attribute: attribute, value: nil}), do: "ssrc:#{id} #{attribute}"
+
+  def to_string(%Ssrc{id: id, attribute: attribute, value: value}),
+    do: "ssrc:#{id} #{attribute}:#{value}"
+end

--- a/lib/ex_sdp/attribute/ssrc.ex
+++ b/lib/ex_sdp/attribute/ssrc.ex
@@ -1,4 +1,4 @@
-defmodule ExSDP.Attribute.Ssrc do
+defmodule ExSDP.Attribute.SSRC do
   @moduledoc """
   This module represents ssrc (RFC 5576).
   """
@@ -29,11 +29,11 @@ defmodule ExSDP.Attribute.Ssrc do
   end
 end
 
-defimpl String.Chars, for: ExSDP.Attribute.Ssrc do
-  alias ExSDP.Attribute.Ssrc
+defimpl String.Chars, for: ExSDP.Attribute.SSRC do
+  alias ExSDP.Attribute.SSRC
 
-  def to_string(%Ssrc{id: id, attribute: attribute, value: nil}), do: "ssrc:#{id} #{attribute}"
+  def to_string(%SSRC{id: id, attribute: attribute, value: nil}), do: "ssrc:#{id} #{attribute}"
 
-  def to_string(%Ssrc{id: id, attribute: attribute, value: value}),
+  def to_string(%SSRC{id: id, attribute: attribute, value: value}),
     do: "ssrc:#{id} #{attribute}:#{value}"
 end

--- a/lib/ex_sdp/bandwidth.ex
+++ b/lib/ex_sdp/bandwidth.ex
@@ -10,16 +10,16 @@ defmodule ExSDP.Bandwidth do
   @enforce_keys [:type, :bandwidth]
   defstruct @enforce_keys
 
-  @type type :: :CT | :AS
-
-  @supported_types ["CT", "AS"]
-
   @type t :: %__MODULE__{
           type: type(),
           bandwidth: non_neg_integer()
         }
 
-  @spec parse(binary()) :: {:error, :invalid_bandwidth} | {:ok, t()}
+  @type type :: :CT | :AS
+
+  @supported_types ["CT", "AS"]
+
+  @spec parse(binary()) :: {:ok, t()} | {:error, :invalid_bandwidth}
   def parse(bandwidth) do
     with [type, bandwidth] <- String.split(bandwidth, ":"),
          {:ok, bandwidth} <- parse_bandwidth(bandwidth),

--- a/lib/ex_sdp/connection_data.ex
+++ b/lib/ex_sdp/connection_data.ex
@@ -57,7 +57,7 @@ defmodule ExSDP.ConnectionData do
 
       {:ok, connection_data}
     else
-      {:error, reason} = error -> error
+      {:error, _reason} = error -> error
     end
   end
 

--- a/lib/ex_sdp/connection_data.ex
+++ b/lib/ex_sdp/connection_data.ex
@@ -21,12 +21,6 @@ defmodule ExSDP.ConnectionData do
 
   alias ExSDP.{Address, Utils}
 
-  @type reason ::
-          :invalid_addrtype
-          | :invalid_address
-          | :ip6_cannot_have_ttl
-          | :invalid_ttl_or_address_count
-
   @enforce_keys [:address]
   defstruct @enforce_keys ++ [:address_count, :ttl, network_type: "IN"]
 
@@ -37,7 +31,13 @@ defmodule ExSDP.ConnectionData do
           network_type: binary()
         }
 
-  @spec parse(binary()) :: {:ok, t()} | {:error, {:invalid_connection_data, reason}}
+  @type reason ::
+          :invalid_addrtype
+          | :invalid_address
+          | :ip6_cannot_have_ttl
+          | :invalid_ttl_or_address_count
+
+  @spec parse(binary()) :: {:ok, t()} | {:error, reason}
   def parse(connection) do
     with {:ok, [nettype, addrtype, connection_address]} <- Utils.split(connection, " ", 3),
          {:ok, addrtype} <- Address.parse_addrtype(addrtype),
@@ -57,7 +57,7 @@ defmodule ExSDP.ConnectionData do
 
       {:ok, connection_data}
     else
-      {:error, reason} -> {:error, {:invalid_connection_data, reason}}
+      {:error, reason} = error -> error
     end
   end
 

--- a/lib/ex_sdp/media.ex
+++ b/lib/ex_sdp/media.ex
@@ -74,7 +74,11 @@ defmodule ExSDP.Media do
   end
 
   @spec add_attribute(media :: t(), attribute :: Attribute.t()) :: t()
-  def add_attribute(media, attribute), do: Map.update!(media, :attributes, &(&1 ++ [attribute]))
+  def add_attribute(media, attribute), do: add_attributes(media, [attribute])
+
+  @spec add_attributes(media :: t(), attributes :: [Attribute.t()]) :: t()
+  def add_attributes(media, attributes) when is_list(attributes),
+    do: Map.update!(media, :attributes, &(&1 ++ attributes))
 
   @spec get_attribute(media :: t(), key :: module() | atom() | binary()) :: Attribute.t()
   def get_attribute(media, key) do

--- a/lib/ex_sdp/media.ex
+++ b/lib/ex_sdp/media.ex
@@ -121,12 +121,14 @@ defmodule ExSDP.Media do
   def parse_optional(["i=" <> title | rest], media),
     do: parse_optional(rest, %__MODULE__{media | title: title})
 
-  def parse_optional(["c=" <> conn | rest], %__MODULE__{connection_data: info} = media) do
-    with {:ok, conn} <- ConnectionData.parse(conn) do
-      conn
-      |> Bunch.listify()
-      ~> %__MODULE__{media | connection_data: %ConnectionData{addresses: &1 ++ info}}
-      ~> parse_optional(rest, &1)
+  def parse_optional(["c=" <> conn | rest], media) do
+    with {:ok, %ConnectionData{} = connection_data} <- ConnectionData.parse(conn) do
+      connection_data = %__MODULE__{
+        media
+        | connection_data: media.connection_data ++ [connection_data]
+      }
+
+      parse_optional(rest, connection_data)
     end
   end
 

--- a/lib/ex_sdp/media.ex
+++ b/lib/ex_sdp/media.ex
@@ -51,7 +51,9 @@ defmodule ExSDP.Media do
   # For searching struct attributes by atoms
   @struct_attr_keys %{
     :rtpmap => RTPMapping,
-    :msid => Msid
+    :msid => Msid,
+    :fmtp => Fmtp,
+    :ssrc => Ssrc
   }
 
   @spec new(
@@ -123,11 +125,8 @@ defmodule ExSDP.Media do
 
   def parse_optional(["c=" <> conn | rest], media) do
     with {:ok, %ConnectionData{} = connection_data} <- ConnectionData.parse(conn) do
-      connection_data = %__MODULE__{
-        media
-        | connection_data: media.connection_data ++ [connection_data]
-      }
-
+      connection_data = media.connection_data ++ [connection_data]
+      connection_data = %__MODULE__{media | connection_data: connection_data}
       parse_optional(rest, connection_data)
     end
   end
@@ -184,7 +183,7 @@ defmodule ExSDP.Media do
 
   defp parse_type(type) when is_binary(type), do: type
 
-  defp parse_fmt(fmt, proto) when proto == "RTP/AVP" or proto == "RTP/SAVP" do
+  defp parse_fmt(fmt, proto) when proto in ["RTP/AVP", "RTP/SAVP", "UDP/TLS/RTP/SAVPF"] do
     fmt
     |> String.split(" ")
     |> Bunch.Enum.try_map(fn single_fmt ->

--- a/lib/ex_sdp/media.ex
+++ b/lib/ex_sdp/media.ex
@@ -49,7 +49,10 @@ defmodule ExSDP.Media do
   @type type :: :audio | :video | :text | :application | :message | binary()
 
   # For searching struct attributes by atoms
-  @struct_attr_keys %{:rtpmap => RTPMapping}
+  @struct_attr_keys %{
+    :rtpmap => RTPMapping,
+    :msid => Msid
+  }
 
   @spec new(
           type :: type(),

--- a/lib/ex_sdp/media.ex
+++ b/lib/ex_sdp/media.ex
@@ -51,9 +51,9 @@ defmodule ExSDP.Media do
   # For searching struct attributes by atoms
   @struct_attr_keys %{
     :rtpmap => RTPMapping,
-    :msid => Msid,
-    :fmtp => Fmtp,
-    :ssrc => Ssrc
+    :msid => MSID,
+    :fmtp => FMTP,
+    :ssrc => SSRC
   }
 
   @spec new(

--- a/lib/ex_sdp/origin.ex
+++ b/lib/ex_sdp/origin.ex
@@ -34,7 +34,7 @@ defmodule ExSDP.Origin do
   * `username` is `-`
   * `session_id` is random 64 bit number
   * `session_version` is `0`
-  * `address` is `ExSDP.ConnectionData.IP4` with `127.0.0.1` address
+  * `address` is `{127, 0, 0, 1}`
   """
   @spec new(
           username: binary(),

--- a/lib/ex_sdp/origin.ex
+++ b/lib/ex_sdp/origin.ex
@@ -58,7 +58,6 @@ defmodule ExSDP.Origin do
            Utils.split(origin, " ", 6),
          {:ok, addrtype} <- Address.parse_addrtype(addrtype),
          {:ok, address} <- Address.parse_address(address) do
-      username = if username == "-", do: nil, else: username
       # check whether fqdn
       address = if is_binary(address), do: {addrtype, address}, else: address
 

--- a/lib/ex_sdp/origin.ex
+++ b/lib/ex_sdp/origin.ex
@@ -83,7 +83,7 @@ defmodule ExSDP.Origin do
   @spec bump_version(t()) :: {:ok, t()}
   def bump_version(origin), do: {:ok, %{origin | session_version: origin.session_version + 1}}
 
-  defp generate_random(), do: :crypto.strong_rand_bytes(8) |> :binary.decode_unsigned()
+  defp generate_random(), do: :crypto.strong_rand_bytes(7) |> :binary.decode_unsigned()
 end
 
 defimpl String.Chars, for: ExSDP.Origin do

--- a/lib/ex_sdp/origin.ex
+++ b/lib/ex_sdp/origin.ex
@@ -52,7 +52,7 @@ defmodule ExSDP.Origin do
   end
 
   @spec parse(binary()) ::
-          {:ok, t()} | {:error, {:invalid_origin, :invalid_addrtype | :invalid_address}}
+          {:ok, t()} | {:error, :invalid_addrtype | :invalid_address}
   def parse(origin) do
     with {:ok, [username, sess_id, sess_version, nettype, addrtype, address]} <-
            Utils.split(origin, " ", 6),
@@ -72,7 +72,7 @@ defmodule ExSDP.Origin do
 
       {:ok, origin}
     else
-      {:error, reason} -> {:error, {:invalid_origin, reason}}
+      {:error, _reason} = error -> error
     end
   end
 

--- a/lib/ex_sdp/parser.ex
+++ b/lib/ex_sdp/parser.ex
@@ -146,7 +146,7 @@ defmodule ExSDP.Parser do
     end
   end
 
-  defp format_error(["m=" <> _ = line | rest], {invalid_line, reason}) do
+  defp format_error(["m=" <> _ = line | rest], reason) do
     attributes =
       rest
       |> Enum.take_while(fn
@@ -162,15 +162,15 @@ defmodule ExSDP.Parser do
     Attributes:
     #{attributes}
 
-    with reason: #{invalid_line} #{reason}
+    with reason: #{reason}
     """
   end
 
-  defp format_error([line | _], {invalid_line, reason}) do
+  defp format_error([line | _], reason) do
     """
     An error has occurred while parsing following SDP line:
     #{line}
-    with reason: #{invalid_line} #{reason}
+    with reason: #{reason}
     """
   end
 

--- a/lib/ex_sdp/parser.ex
+++ b/lib/ex_sdp/parser.ex
@@ -97,8 +97,8 @@ defmodule ExSDP.Parser do
     do: {rest, %ExSDP{spec | phone_number: phone_number}}
 
   defp parse_line(["c=" <> connection_data | rest], spec) do
-    with {:ok, addresses} <- ConnectionData.parse(connection_data) do
-      {rest, %ExSDP{spec | connection_data: %ConnectionData{addresses: [addresses]}}}
+    with {:ok, %ConnectionData{} = connection_data} <- ConnectionData.parse(connection_data) do
+      {rest, %ExSDP{spec | connection_data: connection_data}}
     end
   end
 
@@ -146,7 +146,7 @@ defmodule ExSDP.Parser do
     end
   end
 
-  defp format_error(["m=" <> _ = line | rest], reason) do
+  defp format_error(["m=" <> _ = line | rest], {invalid_line, reason}) do
     attributes =
       rest
       |> Enum.take_while(fn
@@ -162,15 +162,15 @@ defmodule ExSDP.Parser do
     Attributes:
     #{attributes}
 
-    with reason: #{reason}
+    with reason: #{invalid_line} #{reason}
     """
   end
 
-  defp format_error([line | _], reason) do
+  defp format_error([line | _], {invalid_line, reason}) do
     """
     An error has occurred while parsing following SDP line:
     #{line}
-    with reason: #{reason}
+    with reason: #{invalid_line} #{reason}
     """
   end
 

--- a/lib/ex_sdp/serializer.ex
+++ b/lib/ex_sdp/serializer.ex
@@ -27,6 +27,7 @@ defmodule ExSDP.Serializer do
 
   def maybe_serialize(type, {:setup, value}), do: "#{type}=setup:#{serialize_setup(value)}"
   def maybe_serialize(type, {:mid, value}), do: "#{type}=mid:#{value}"
+  def maybe_serialize(type, {:group, value}), do: "#{type}=group:#{serialize_group(value)}"
   def maybe_serialize(type, :rtcp_mux), do: "#{type}=rtcp-mux"
   def maybe_serialize(type, :rtcp_rsize), do: "#{type}=rtcp-rsize"
 
@@ -56,4 +57,9 @@ defmodule ExSDP.Serializer do
 
   defp serialize_setup(setup) when setup in [:active, :passive, :actpass, :holdconn],
     do: Atom.to_string(setup)
+
+  defp serialize_group({semantic, ids}) do
+    ids = Enum.join(ids, " ")
+    "#{semantic} #{ids}"
+  end
 end

--- a/lib/ex_sdp/serializer.ex
+++ b/lib/ex_sdp/serializer.ex
@@ -13,16 +13,47 @@ defmodule ExSDP.Serializer do
   def maybe_serialize(type, values) when is_list(values),
     do: Enum.map_join(values, "\n", fn value -> maybe_serialize(type, value) end)
 
-  def maybe_serialize(type, {key, {frames, sec}}), do: "#{type}=#{key}:#{frames}/#{sec}"
+  def maybe_serialize(type, {:framerate, {frames, sec}}),
+    do: "#{type}=framerate:#{frames}/#{sec}"
 
-  def maybe_serialize(type, {key, value}), do: "#{type}=#{key}:#{value}"
+  def maybe_serialize(type, {:ice_ufrag, value}), do: "#{type}=ice-ufrag:#{value}"
+  def maybe_serialize(type, {:ice_pwd, value}), do: "#{type}=ice-pwd:#{value}"
+
+  def maybe_serialize(type, {:ice_options, value}),
+    do: "#{type}=ice-options:#{serialize_ice_options(value)}"
+
+  def maybe_serialize(type, {:fingerprint, value}),
+    do: "#{type}=fingerprint:#{serialize_fingerprint(value)}"
+
+  def maybe_serialize(type, {:setup, value}), do: "#{type}=setup:#{serialize_setup(value)}"
+  def maybe_serialize(type, {:mid, value}), do: "#{type}=mid:#{value}"
+  def maybe_serialize(type, :rtcp_mux), do: "#{type}=rtcp-mux"
+  def maybe_serialize(type, :rtcp_rsize), do: "#{type}=rtcp-rsize"
 
   def maybe_serialize(type, true), do: "#{type}=1"
   def maybe_serialize(type, false), do: "#{type}=0"
+  def maybe_serialize(type, {key, value}), do: "#{type}=#{key}:#{value}"
   def maybe_serialize(type, value), do: "#{type}=#{value}"
 
   def maybe_serialize_hex(_type, nil), do: ""
 
   def maybe_serialize_hex(type, value),
     do: "#{type}=#{Integer.to_string(value, 16) |> String.downcase()}"
+
+  defp serialize_ice_options(ice_options) do
+    Bunch.listify(ice_options) |> Enum.join(" ")
+  end
+
+  defp serialize_fingerprint(fingerprint) do
+    case fingerprint do
+      {:sha1, value} -> "sha-1 #{value}"
+      {:sha224, value} -> "sha-224 #{value}"
+      {:sha256, value} -> "sha-256 #{value}"
+      {:sha384, value} -> "sha-384 #{value}"
+      {:sha512, value} -> "sha-512 #{value}"
+    end
+  end
+
+  defp serialize_setup(setup) when setup in [:active, :passive, :actpass, :holdconn],
+    do: Atom.to_string(setup)
 end

--- a/lib/ex_sdp/serializer.ex
+++ b/lib/ex_sdp/serializer.ex
@@ -4,9 +4,7 @@ defmodule ExSDP.Serializer do
   """
 
   @doc """
-  Each SDP line is of the following format:
-    <type>=<value>
-  Function parameters follows this description.
+  Serializes both sdp lines (<type>=<value>) and sdp parameters (<parameter>=<value>)
   """
   @spec maybe_serialize(type :: binary(), value :: term()) :: binary()
   def maybe_serialize(_type, nil), do: ""
@@ -19,5 +17,12 @@ defmodule ExSDP.Serializer do
 
   def maybe_serialize(type, {key, value}), do: "#{type}=#{key}:#{value}"
 
+  def maybe_serialize(type, true), do: "#{type}=1"
+  def maybe_serialize(type, false), do: "#{type}=0"
   def maybe_serialize(type, value), do: "#{type}=#{value}"
+
+  def maybe_serialize_hex(_type, nil), do: ""
+
+  def maybe_serialize_hex(type, value),
+    do: "#{type}=#{Integer.to_string(value, 16) |> String.downcase()}"
 end

--- a/lib/ex_sdp/utils.ex
+++ b/lib/ex_sdp/utils.ex
@@ -1,0 +1,15 @@
+defmodule ExSDP.Utils do
+  @moduledoc false
+
+  def split(origin, delim, expected_len) do
+    split = String.split(origin, delim)
+    if length(split) == expected_len, do: {:ok, split}, else: {:error, :too_few_fields}
+  end
+
+  def parse_numeric_string(string) do
+    case Integer.parse(string) do
+      {number, ""} -> {:ok, number}
+      _ -> {:error, :string_nan}
+    end
+  end
+end

--- a/lib/ex_sdp/utils.ex
+++ b/lib/ex_sdp/utils.ex
@@ -2,7 +2,7 @@ defmodule ExSDP.Utils do
   @moduledoc false
 
   def split(origin, delim, expected_len) do
-    split = String.split(origin, delim)
+    split = String.split(origin, delim, parts: expected_len)
     if length(split) == expected_len, do: {:ok, split}, else: {:error, :too_few_fields}
   end
 

--- a/lib/ex_sdp/utils.ex
+++ b/lib/ex_sdp/utils.ex
@@ -12,4 +12,19 @@ defmodule ExSDP.Utils do
       _ -> {:error, :string_nan}
     end
   end
+
+  def parse_numeric_hex_string(string) do
+    case Integer.parse(string, 16) do
+      {number, ""} -> {:ok, number}
+      _ -> {:error, :string_not_hex}
+    end
+  end
+
+  def parse_numeric_bool_string(string) do
+    case Integer.parse(string) do
+      {0, ""} -> {:ok, false}
+      {1, ""} -> {:ok, true}
+      _ -> {:error, :string_not_0_nor_1}
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -52,6 +52,7 @@ defmodule ExSDP.MixProject do
   defp deps do
     [
       {:bunch, "~> 1.3"},
+      {:uuid, "~> 1.1"},
       {:dialyxir, "~> 1.0.0", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.23", only: :dev, runtime: false},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -13,4 +13,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.0", "98312c9f0d3730fde4049985a1105da5155bfe5c11e47bdc7406d88e01e4219b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "75ffa34ab1056b7e24844c90bfc62aaf6f3a37a15faa76b07bc5eba27e4a8b4a"},
   "mix_test_watch": {:hex, :mix_test_watch, "1.0.2", "34900184cbbbc6b6ed616ed3a8ea9b791f9fd2088419352a6d3200525637f785", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm", "47ac558d8b06f684773972c6d04fcc15590abdb97aeb7666da19fcbfdc441a07"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm", "c790593b4c3b601f5dc2378baae7efaf5b3d73c4c6456ba85759905be792f2ac"},
 }

--- a/test/ex_sdp/attribute/fmtp_test.exs
+++ b/test/ex_sdp/attribute/fmtp_test.exs
@@ -1,31 +1,31 @@
-defmodule ExSDP.Attribute.FmtpTest do
+defmodule ExSDP.Attribute.FMTPTest do
   use ExUnit.Case
 
-  alias ExSDP.Attribute.Fmtp
+  alias ExSDP.Attribute.FMTP
 
-  describe "Fmtp parser" do
+  describe "FMTP parser" do
     test "parses fmtp" do
       fmtp = "108 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1"
 
-      expected = %Fmtp{
+      expected = %FMTP{
         pt: 108,
         profile_level_id: 0x42E01F,
         level_asymmetry_allowed: true,
         packetization_mode: 1
       }
 
-      assert {:ok, expected} == Fmtp.parse(fmtp)
+      assert {:ok, expected} == FMTP.parse(fmtp)
     end
 
     test "returns an error when there is unsupported parameter" do
       fmtp = "108 profile-level-id=42e01f;level-asymmetry-allowed=1;unsupported-param=1"
-      assert {:error, :unsupported_parameter} = Fmtp.parse(fmtp)
+      assert {:error, :unsupported_parameter} = FMTP.parse(fmtp)
     end
   end
 
-  describe "Fmtp serializer" do
-    test "serializes fmtp with numeric and boolean values" do
-      fmtp = %Fmtp{
+  describe "FMTP serializer" do
+    test "serializes FMTP with numeric and boolean values" do
+      fmtp = %FMTP{
         pt: 120,
         minptime: 10,
         useinbandfec: true
@@ -34,10 +34,10 @@ defmodule ExSDP.Attribute.FmtpTest do
       assert "#{fmtp}" == "fmtp:120 minptime=10;useinbandfec=1"
     end
 
-    test "serializes fmtp with hexadecimal numeric values and boolean values" do
+    test "serializes FMTP with hexadecimal numeric values and boolean values" do
       expected = "fmtp:108 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1"
 
-      fmtp = %Fmtp{
+      fmtp = %FMTP{
         pt: 108,
         profile_level_id: 0x42E01F,
         level_asymmetry_allowed: true,

--- a/test/ex_sdp/attribute/fmtp_test.exs
+++ b/test/ex_sdp/attribute/fmtp_test.exs
@@ -1,0 +1,50 @@
+defmodule ExSDP.Attribute.FmtpTest do
+  use ExUnit.Case
+
+  alias ExSDP.Attribute.Fmtp
+
+  describe "Fmtp parser" do
+    test "parses fmtp" do
+      fmtp = "108 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1"
+
+      expected = %Fmtp{
+        pt: 108,
+        profile_level_id: 0x42E01F,
+        level_asymmetry_allowed: true,
+        packetization_mode: 1
+      }
+
+      assert {:ok, expected} == Fmtp.parse(fmtp)
+    end
+
+    test "returns an error when there is unsupported parameter" do
+      fmtp = "108 profile-level-id=42e01f;level-asymmetry-allowed=1;unsupported-param=1"
+      assert {:error, {:invalid_fmtp, :unsupported_parameter}} = Fmtp.parse(fmtp)
+    end
+  end
+
+  describe "Fmtp serializer" do
+    test "serializes fmtp with numeric and boolean values" do
+      fmtp = %Fmtp{
+        pt: 120,
+        minptime: 10,
+        useinbandfec: true
+      }
+
+      assert "#{fmtp}" == "fmtp:120 minptime=10;useinbandfec=1"
+    end
+
+    test "serializes fmtp with hexadecimal numeric values and boolean values" do
+      expected = "fmtp:108 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1"
+
+      fmtp = %Fmtp{
+        pt: 108,
+        profile_level_id: 0x42E01F,
+        level_asymmetry_allowed: true,
+        packetization_mode: 1
+      }
+
+      assert "#{fmtp}" == expected
+    end
+  end
+end

--- a/test/ex_sdp/attribute/fmtp_test.exs
+++ b/test/ex_sdp/attribute/fmtp_test.exs
@@ -19,7 +19,7 @@ defmodule ExSDP.Attribute.FmtpTest do
 
     test "returns an error when there is unsupported parameter" do
       fmtp = "108 profile-level-id=42e01f;level-asymmetry-allowed=1;unsupported-param=1"
-      assert {:error, {:invalid_fmtp, :unsupported_parameter}} = Fmtp.parse(fmtp)
+      assert {:error, :unsupported_parameter} = Fmtp.parse(fmtp)
     end
   end
 

--- a/test/ex_sdp/attribute/msid_test.exs
+++ b/test/ex_sdp/attribute/msid_test.exs
@@ -26,15 +26,15 @@ defmodule ExSDP.Attribute.MsidTest do
 
   describe "Msid serializer" do
     test "serializes msid without app data" do
-      msid_id = Msid.generate_random()
+      msid_id = UUID.uuid4()
       msid = Msid.new(msid_id, nil)
 
       assert "#{msid}" == "msid:#{msid_id}"
     end
 
     test "serializes msid with app data" do
-      id = Msid.generate_random()
-      app_data = Msid.generate_random()
+      id = UUID.uuid4()
+      app_data = UUID.uuid4()
       msid = Msid.new(id, app_data)
 
       assert "#{msid}" == "msid:#{id} #{app_data}"

--- a/test/ex_sdp/attribute/msid_test.exs
+++ b/test/ex_sdp/attribute/msid_test.exs
@@ -1,0 +1,43 @@
+defmodule ExSDP.Attribute.MsidTest do
+  use ExUnit.Case
+
+  alias ExSDP.Attribute.Msid
+
+  describe "Msid parser" do
+    test "parses msid without app data" do
+      id = "0YiRg3sIeAEZEhwD3ANvRbn7UFf3BjYBeANS"
+      assert {:ok, msid} = Msid.parse(id)
+      assert %Msid{id: id} = msid
+    end
+
+    test "parses msid with app data" do
+      id = "0YiRg3sIeAEZEhwD3ANvRbn7UFf3BjYBeANS"
+      app_data = "a60cccca-f708-49e7-89d0-4be0524658a5"
+      assert {:ok, msid} = Msid.parse("#{id} #{app_data}")
+      assert %Msid{id: id, app_data: app_data} = msid
+    end
+
+    test "returns an error when id is empty" do
+      app_data = "a60cccca-f708-49e7-89d0-4be0524658a5"
+      assert {:error, :invalid_msid} = Msid.parse("")
+      assert {:error, :invalid_msid} = Msid.parse(" #{app_data}")
+    end
+  end
+
+  describe "Msid serializer" do
+    test "serializes msid without app data" do
+      msid_id = Msid.generate_random()
+      msid = Msid.new(msid_id, nil)
+
+      assert "#{msid}" == "msid:#{msid_id}"
+    end
+
+    test "serializes msid with app data" do
+      id = Msid.generate_random()
+      app_data = Msid.generate_random()
+      msid = Msid.new(id, app_data)
+
+      assert "#{msid}" == "msid:#{id} #{app_data}"
+    end
+  end
+end

--- a/test/ex_sdp/attribute/msid_test.exs
+++ b/test/ex_sdp/attribute/msid_test.exs
@@ -1,41 +1,41 @@
-defmodule ExSDP.Attribute.MsidTest do
+defmodule ExSDP.Attribute.MSIDTest do
   use ExUnit.Case
 
-  alias ExSDP.Attribute.Msid
+  alias ExSDP.Attribute.MSID
 
-  describe "Msid parser" do
+  describe "MSID parser" do
     test "parses msid without app data" do
       id = "0YiRg3sIeAEZEhwD3ANvRbn7UFf3BjYBeANS"
-      assert {:ok, msid} = Msid.parse(id)
-      assert %Msid{id: id} = msid
+      assert {:ok, msid} = MSID.parse(id)
+      assert %MSID{id: id} = msid
     end
 
     test "parses msid with app data" do
       id = "0YiRg3sIeAEZEhwD3ANvRbn7UFf3BjYBeANS"
       app_data = "a60cccca-f708-49e7-89d0-4be0524658a5"
-      assert {:ok, msid} = Msid.parse("#{id} #{app_data}")
-      assert %Msid{id: id, app_data: app_data} = msid
+      assert {:ok, msid} = MSID.parse("#{id} #{app_data}")
+      assert %MSID{id: id, app_data: app_data} = msid
     end
 
     test "returns an error when id is empty" do
       app_data = "a60cccca-f708-49e7-89d0-4be0524658a5"
-      assert {:error, :invalid_msid} = Msid.parse("")
-      assert {:error, :invalid_msid} = Msid.parse(" #{app_data}")
+      assert {:error, :invalid_msid} = MSID.parse("")
+      assert {:error, :invalid_msid} = MSID.parse(" #{app_data}")
     end
   end
 
-  describe "Msid serializer" do
-    test "serializes msid without app data" do
+  describe "MSID serializer" do
+    test "serializes MSID without app data" do
       msid_id = UUID.uuid4()
-      msid = Msid.new(msid_id, nil)
+      msid = MSID.new(msid_id, nil)
 
       assert "#{msid}" == "msid:#{msid_id}"
     end
 
-    test "serializes msid with app data" do
+    test "serializes MSID with app data" do
       id = UUID.uuid4()
       app_data = UUID.uuid4()
-      msid = Msid.new(id, app_data)
+      msid = MSID.new(id, app_data)
 
       assert "#{msid}" == "msid:#{id} #{app_data}"
     end

--- a/test/ex_sdp/attribute/rtp_mapping_test.exs
+++ b/test/ex_sdp/attribute/rtp_mapping_test.exs
@@ -37,7 +37,7 @@ defmodule ExSDP.Attribute.RTPMappingTest do
     end
 
     test "returns an error when clock_rate or payload type is not a number" do
-      assert {:error, :invalid_attribute} = RTPMapping.parse("9t9 h264/90000", media_type: :video)
+      assert {:error, :string_nan} = RTPMapping.parse("9t9 h264/90000", media_type: :video)
     end
   end
 

--- a/test/ex_sdp/attribute/ssrc_test.exs
+++ b/test/ex_sdp/attribute/ssrc_test.exs
@@ -1,0 +1,36 @@
+defmodule ExSDP.Attribute.SsrcTest do
+  use ExUnit.Case
+
+  alias ExSDP.Attribute.Ssrc
+
+  describe "Ssrc parser" do
+    test "parses ssrc with attribute and value" do
+      ssrc = "4112531724 cname:HPd3XfRHXYUxzfsJ"
+      expected = %Ssrc{id: 4_112_531_724, attribute: "cname", value: "HPd3XfRHXYUxzfsJ"}
+      assert {:ok, expected} == Ssrc.parse(ssrc)
+    end
+
+    test "parses ssrc only with attribute" do
+      ssrc = "4112531724 some-attr"
+      expected = %Ssrc{id: 4_112_531_724, attribute: "some-attr", value: nil}
+      assert {:ok, expected} == Ssrc.parse(ssrc)
+    end
+
+    test "returns an error when there is no attribute after id" do
+      ssrc = "4112531724"
+      assert {:error, :invalid_ssrc} = Ssrc.parse(ssrc)
+    end
+  end
+
+  describe "Ssrc serializer" do
+    test "serializes ssrc with attribute and value" do
+      ssrc = %Ssrc{id: 4_112_531_724, attribute: "cname", value: "HPd3XfRHXYUxzfsJ"}
+      assert "#{ssrc}" == "ssrc:4112531724 cname:HPd3XfRHXYUxzfsJ"
+    end
+
+    test "serializes ssrc only with attribute" do
+      ssrc = %Ssrc{id: 4_112_531_724, attribute: "some-attr"}
+      assert "#{ssrc}" == "ssrc:4112531724 some-attr"
+    end
+  end
+end

--- a/test/ex_sdp/attribute/ssrc_test.exs
+++ b/test/ex_sdp/attribute/ssrc_test.exs
@@ -1,35 +1,35 @@
-defmodule ExSDP.Attribute.SsrcTest do
+defmodule ExSDP.Attribute.SSRCTest do
   use ExUnit.Case
 
-  alias ExSDP.Attribute.Ssrc
+  alias ExSDP.Attribute.SSRC
 
-  describe "Ssrc parser" do
+  describe "SSRC parser" do
     test "parses ssrc with attribute and value" do
       ssrc = "4112531724 cname:HPd3XfRHXYUxzfsJ"
-      expected = %Ssrc{id: 4_112_531_724, attribute: "cname", value: "HPd3XfRHXYUxzfsJ"}
-      assert {:ok, expected} == Ssrc.parse(ssrc)
+      expected = %SSRC{id: 4_112_531_724, attribute: "cname", value: "HPd3XfRHXYUxzfsJ"}
+      assert {:ok, expected} == SSRC.parse(ssrc)
     end
 
     test "parses ssrc only with attribute" do
       ssrc = "4112531724 some-attr"
-      expected = %Ssrc{id: 4_112_531_724, attribute: "some-attr", value: nil}
-      assert {:ok, expected} == Ssrc.parse(ssrc)
+      expected = %SSRC{id: 4_112_531_724, attribute: "some-attr", value: nil}
+      assert {:ok, expected} == SSRC.parse(ssrc)
     end
 
     test "returns an error when there is no attribute after id" do
       ssrc = "4112531724"
-      assert {:error, :invalid_ssrc} = Ssrc.parse(ssrc)
+      assert {:error, :invalid_ssrc} = SSRC.parse(ssrc)
     end
   end
 
-  describe "Ssrc serializer" do
-    test "serializes ssrc with attribute and value" do
-      ssrc = %Ssrc{id: 4_112_531_724, attribute: "cname", value: "HPd3XfRHXYUxzfsJ"}
+  describe "SSRC serializer" do
+    test "serializes SSRC with attribute and value" do
+      ssrc = %SSRC{id: 4_112_531_724, attribute: "cname", value: "HPd3XfRHXYUxzfsJ"}
       assert "#{ssrc}" == "ssrc:4112531724 cname:HPd3XfRHXYUxzfsJ"
     end
 
-    test "serializes ssrc only with attribute" do
-      ssrc = %Ssrc{id: 4_112_531_724, attribute: "some-attr"}
+    test "serializes SSRC only with attribute" do
+      ssrc = %SSRC{id: 4_112_531_724, attribute: "some-attr"}
       assert "#{ssrc}" == "ssrc:4112531724 some-attr"
     end
   end

--- a/test/ex_sdp/connection_data_test.exs
+++ b/test/ex_sdp/connection_data_test.exs
@@ -65,25 +65,24 @@ defmodule ExSDP.ConnectionDataTest do
 
   describe "Connection information parser returns an error when" do
     test "connection spec is invalid" do
-      assert {:error, {:invalid_connection_data, :too_few_fields}} =
-               ConnectionData.parse("IN EPI")
+      assert {:error, :too_few_fields} = ConnectionData.parse("IN EPI")
     end
 
     test "address is not valid" do
-      assert {:error, {:invalid_connection_data, :invalid_ttl_or_address_count}} =
+      assert {:error, :invalid_ttl_or_address_count} =
                ConnectionData.parse("IN IP4 224.2.1.1/127/3/4")
     end
 
     test "either ttl or count is not an integer" do
-      assert {:error, {:invalid_connection_data, :invalid_ttl_or_address_count}} =
+      assert {:error, :invalid_ttl_or_address_count} =
                ConnectionData.parse("IN IP4 224.2.1.1/127/3d")
 
-      assert {:error, {:invalid_connection_data, :invalid_ttl_or_address_count}} =
+      assert {:error, :invalid_ttl_or_address_count} =
                ConnectionData.parse("IN IP4 224.2.1.1/127a/3")
     end
 
     test "ttl is not in 0..255 range" do
-      assert {:error, {:invalid_connection_data, :invalid_ttl_or_address_count}} =
+      assert {:error, :invalid_ttl_or_address_count} =
                ConnectionData.parse("IN IP4 224.2.1.1/256")
     end
   end

--- a/test/ex_sdp/media_test.exs
+++ b/test/ex_sdp/media_test.exs
@@ -97,31 +97,14 @@ defmodule ExSDP.MediaTest do
         |> Media.parse()
 
       bandwidth = [%Bandwidth{bandwidth: 128, type: "X-YZ"}]
-
-      connection_data = [
-        %ConnectionData{
-          addresses: [
-            %ConnectionData.IP4{
-              ttl: 127,
-              value: {224, 2, 17, 12}
-            }
-          ]
-        }
-      ]
-
+      connection_data = %ConnectionData{ttl: 127, address: {224, 2, 17, 12}}
       encryption = %Encryption{method: :clear}
 
       session = %ExSDP{
         connection_data: connection_data,
         origin: %Origin{
           session_id: 2_890_844_526,
-          address: %ConnectionData{
-            addresses: [
-              %ConnectionData.IP4{
-                value: {10, 47, 16, 5}
-              }
-            ]
-          },
+          address: %ConnectionData{address: {10, 47, 16, 5}},
           username: "-",
           session_version: 2_890_842_807
         },
@@ -177,14 +160,7 @@ defmodule ExSDP.MediaTest do
 
       assert %Media{
                bandwidth: [%Bandwidth{bandwidth: 128, type: :AS}],
-               connection_data: %ConnectionData{
-                 addresses: [
-                   %ConnectionData.IP4{
-                     ttl: 220,
-                     value: {144, 2, 17, 12}
-                   }
-                 ]
-               },
+               connection_data: [%ConnectionData{ttl: 220, address: {144, 2, 17, 12}}],
                encryption: %Encryption{key: nil, method: :prompt}
              } = result
     end
@@ -249,16 +225,9 @@ defmodule ExSDP.MediaTest do
 
     test "serializes media with connection_data description" do
       addresses = [
-        %ConnectionData.IP4{
-          ttl: 127,
-          value: {224, 2, 1, 1}
-        },
-        %ConnectionData.IP6{
-          value: {15, 0, 0, 0, 0, 0, 0, 101}
-        },
-        %ConnectionData.FQDN{
-          value: "https://some.uri.net"
-        }
+        %ConnectionData{ttl: 127, address: {224, 2, 1, 1}},
+        %ConnectionData{address: {15, 0, 0, 0, 0, 0, 0, 101}},
+        %ConnectionData{address: {:IP4, "https://some.uri.net"}}
       ]
 
       serialized_addresses = [

--- a/test/ex_sdp/media_test.exs
+++ b/test/ex_sdp/media_test.exs
@@ -22,7 +22,8 @@ defmodule ExSDP.MediaTest do
 
       assert %Media{
                fmt: [31],
-               ports: [49_170],
+               port: 49_170,
+               port_count: 1,
                protocol: "RTP/AVP",
                type: :video
              } = media
@@ -35,7 +36,8 @@ defmodule ExSDP.MediaTest do
 
       assert %Media{
                fmt: [31],
-               ports: [49_170, 49_172],
+               port: 49_170,
+               port_count: 2,
                protocol: "RTP/AVP",
                type: :video
              } = media
@@ -81,7 +83,7 @@ defmodule ExSDP.MediaTest do
       assert %Media{
                attributes: parsed_attributes,
                fmt: [96, 97, 98],
-               ports: [49_230],
+               port: 49_230,
                protocol: "RTP/AVP",
                type: :audio
              } == medium
@@ -206,7 +208,7 @@ defmodule ExSDP.MediaTest do
 
   describe "Media serializer" do
     test "serializes audio description" do
-      media = %Media{type: :audio, protocol: "RTP/AVP", fmt: [0], ports: [49_170]}
+      media = %Media{type: :audio, protocol: "RTP/AVP", fmt: [0], port: 49_170}
       assert "#{media}" == "audio 49170 RTP/AVP 0"
     end
 
@@ -223,7 +225,7 @@ defmodule ExSDP.MediaTest do
       media = %Media{
         type: :video,
         protocol: "RTP/AVP",
-        ports: [51_372],
+        port: 51_372,
         fmt: [99],
         attributes: [attribute]
       }
@@ -234,7 +236,7 @@ defmodule ExSDP.MediaTest do
     test "serializes media description with title, bandwidth and encryption description" do
       media = %Media{
         type: "type",
-        ports: [12_345],
+        port: 12_345,
         title: "title",
         protocol: "some_protocol",
         fmt: [100],
@@ -268,7 +270,7 @@ defmodule ExSDP.MediaTest do
       media = %Media{
         type: :video,
         protocol: "RTP/AVP",
-        ports: [51_372],
+        port: 51_372,
         fmt: [99]
       }
 
@@ -294,7 +296,7 @@ defmodule ExSDP.MediaTest do
       }
 
       media =
-        Media.new(:video, [51_372], "RTP/AVP", [99])
+        Media.new(:video, 51_372, "RTP/AVP", [99])
         |> Media.add_attribute(rtpmap)
 
       attr = Media.get_attribute(media, RTPMapping)

--- a/test/ex_sdp/origin_test.exs
+++ b/test/ex_sdp/origin_test.exs
@@ -1,8 +1,7 @@
 defmodule ExSDP.OriginTest do
   use ExUnit.Case
 
-  alias ExSDP.{ConnectionData, Origin}
-  alias ConnectionData.FQDN
+  alias ExSDP.Origin
 
   describe "Origin parser" do
     test "processes valid origin declaration" do
@@ -10,9 +9,7 @@ defmodule ExSDP.OriginTest do
 
       assert origin == %Origin{
                session_id: 2_890_844_526,
-               address: %ConnectionData.IP4{
-                 value: {10, 47, 16, 5}
-               },
+               address: {10, 47, 16, 5},
                session_version: 2_890_842_807,
                username: "jdoe"
              }
@@ -23,27 +20,26 @@ defmodule ExSDP.OriginTest do
 
       assert origin == %Origin{
                session_id: 2_890_844_526,
-               address: %ConnectionData.IP4{
-                 value: {10, 47, 16, 5}
-               },
+               address: {10, 47, 16, 5},
                session_version: 2_890_842_807,
                username: nil
              }
     end
 
     test "returns an error if declaration is invalid" do
-      assert {:error, :invalid_origin} = Origin.parse("jdoe 2890844526 2890842807")
+      assert {:error, {:invalid_origin, :too_few_fields}} =
+               Origin.parse("jdoe 2890844526 2890842807")
     end
 
     test "returns an error if declaration contains not supported address type" do
-      assert {:error, :invalid_address} =
+      assert {:error, {:invalid_origin, :invalid_addrtype}} =
                Origin.parse("jdoe 2890844526 2890842807 IN NOTIP 10.47.16.5")
     end
 
     test "processes origin with FQDN" do
       assert {:ok,
               %Origin{
-                address: %FQDN{value: "host.origin.name"},
+                address: {:IP4, "host.origin.name"},
                 session_id: 2_890_844_526,
                 session_version: 2_890_842_807,
                 username: "jdoe"
@@ -55,12 +51,12 @@ defmodule ExSDP.OriginTest do
     test "serializes origin" do
       origin = %Origin{
         session_version: 0,
-        address: %FQDN{value: "some.origin.address"},
+        address: {:IP6, "some.origin.address"},
         session_id: 222,
         username: "username_id"
       }
 
-      assert "#{origin}" == "username_id 222 0 IN IP4 some.origin.address"
+      assert "#{origin}" == "username_id 222 0 IN IP6 some.origin.address"
     end
   end
 end

--- a/test/ex_sdp/origin_test.exs
+++ b/test/ex_sdp/origin_test.exs
@@ -27,12 +27,11 @@ defmodule ExSDP.OriginTest do
     end
 
     test "returns an error if declaration is invalid" do
-      assert {:error, {:invalid_origin, :too_few_fields}} =
-               Origin.parse("jdoe 2890844526 2890842807")
+      assert {:error, :too_few_fields} = Origin.parse("jdoe 2890844526 2890842807")
     end
 
     test "returns an error if declaration contains not supported address type" do
-      assert {:error, {:invalid_origin, :invalid_addrtype}} =
+      assert {:error, :invalid_addrtype} =
                Origin.parse("jdoe 2890844526 2890842807 IN NOTIP 10.47.16.5")
     end
 

--- a/test/ex_sdp/origin_test.exs
+++ b/test/ex_sdp/origin_test.exs
@@ -21,8 +21,7 @@ defmodule ExSDP.OriginTest do
       assert origin == %Origin{
                session_id: 2_890_844_526,
                address: {10, 47, 16, 5},
-               session_version: 2_890_842_807,
-               username: nil
+               session_version: 2_890_842_807
              }
     end
 

--- a/test/line_ending_test.exs
+++ b/test/line_ending_test.exs
@@ -2,13 +2,11 @@ defmodule ExSDP.LineEndingTest do
   use ExUnit.Case
   alias ExSDP
 
-  alias ExSDP.{ConnectionData, Origin, Timing}
+  alias ExSDP.{Origin, Timing}
 
   @expected_output %ExSDP{
     origin: %Origin{
-      address: %ConnectionData.IP4{
-        value: {10, 47, 16, 5}
-      },
+      address: {10, 47, 16, 5},
       session_id: 2_890_844_526,
       session_version: 2_890_842_807,
       username: "jdoe"

--- a/test/rfc_spec_test.exs
+++ b/test/rfc_spec_test.exs
@@ -16,8 +16,6 @@ defmodule ExSDP.RFCTest do
     Timing
   }
 
-  alias ConnectionData.{FQDN, IP4}
-
   describe "SDP parser processes SDP specs from RFC" do
     @tag integration: true
     test "Parses single media spec with flag attributes" do
@@ -41,27 +39,13 @@ defmodule ExSDP.RFCTest do
 
       assert session_spec == %ExSDP{
                attributes: [:recvonly],
-               connection_data: %ConnectionData{
-                 addresses: [
-                   %IP4{
-                     ttl: 127,
-                     value: {224, 2, 17, 12}
-                   }
-                 ]
-               },
+               connection_data: %ConnectionData{ttl: 127, address: {224, 2, 17, 12}},
                email: "j.doe@example.com (Jane Doe)",
                media: [
                  %Media{
                    attributes: [],
                    bandwidth: [],
-                   connection_data: %ConnectionData{
-                     addresses: [
-                       %IP4{
-                         ttl: 127,
-                         value: {224, 2, 17, 12}
-                       }
-                     ]
-                   },
+                   connection_data: %ConnectionData{ttl: 127, address: {224, 2, 17, 12}},
                    fmt: [0],
                    port: 49_170,
                    protocol: "RTP/AVP",
@@ -75,14 +59,7 @@ defmodule ExSDP.RFCTest do
                        payload_type: 99
                      }
                    ],
-                   connection_data: %ConnectionData{
-                     addresses: [
-                       %IP4{
-                         ttl: 127,
-                         value: {224, 2, 17, 12}
-                       }
-                     ]
-                   },
+                   connection_data: %ConnectionData{ttl: 127, address: {224, 2, 17, 12}},
                    fmt: [99],
                    port: 51_372,
                    protocol: "RTP/AVP",
@@ -90,9 +67,7 @@ defmodule ExSDP.RFCTest do
                  }
                ],
                origin: %Origin{
-                 address: %IP4{
-                   value: {10, 47, 16, 5}
-                 },
+                 address: {10, 47, 16, 5},
                  session_id: 2_890_844_526,
                  session_version: 2_890_842_807,
                  username: "jdoe"
@@ -131,9 +106,7 @@ defmodule ExSDP.RFCTest do
       assert result == %ExSDP{
                attributes: [],
                bandwidth: [],
-               connection_data: %ConnectionData{
-                 addresses: [%FQDN{value: "host.atlanta.example.com"}]
-               },
+               connection_data: %ConnectionData{address: {:IP4, "host.atlanta.example.com"}},
                email: nil,
                encryption: nil,
                media: [
@@ -159,9 +132,7 @@ defmodule ExSDP.RFCTest do
                      }
                    ],
                    bandwidth: [],
-                   connection_data: %ConnectionData{
-                     addresses: [%FQDN{value: "host.atlanta.example.com"}]
-                   },
+                   connection_data: %ConnectionData{address: {:IP4, "host.atlanta.example.com"}},
                    encryption: nil,
                    fmt: [0, 8, 97],
                    port: 49_170,
@@ -183,9 +154,7 @@ defmodule ExSDP.RFCTest do
                      }
                    ],
                    bandwidth: [],
-                   connection_data: %ConnectionData{
-                     addresses: [%FQDN{value: "host.atlanta.example.com"}]
-                   },
+                   connection_data: %ConnectionData{address: {:IP4, "host.atlanta.example.com"}},
                    encryption: nil,
                    fmt: [31, 32],
                    port: 51_372,
@@ -195,7 +164,7 @@ defmodule ExSDP.RFCTest do
                  }
                ],
                origin: %Origin{
-                 address: %FQDN{value: "host.atlanta.example.com"},
+                 address: {:IP4, "host.atlanta.example.com"},
                  session_id: 2_890_844_526,
                  session_version: 2_890_844_526,
                  username: "alice"
@@ -231,9 +200,7 @@ defmodule ExSDP.RFCTest do
       assert %ExSDP{
                attributes: [],
                bandwidth: [],
-               connection_data: %ConnectionData{
-                 addresses: [%FQDN{value: "host.biloxi.example.com"}]
-               },
+               connection_data: %ConnectionData{address: {:IP4, "host.biloxi.example.com"}},
                email: nil,
                encryption: nil,
                media: [
@@ -247,9 +214,7 @@ defmodule ExSDP.RFCTest do
                      }
                    ],
                    bandwidth: [],
-                   connection_data: %ConnectionData{
-                     addresses: [%FQDN{value: "host.biloxi.example.com"}]
-                   },
+                   connection_data: %ConnectionData{address: {:IP4, "host.biloxi.example.com"}},
                    encryption: nil,
                    fmt: [0],
                    port: 49_174,
@@ -267,9 +232,7 @@ defmodule ExSDP.RFCTest do
                      }
                    ],
                    bandwidth: [],
-                   connection_data: %ConnectionData{
-                     addresses: [%FQDN{value: "host.biloxi.example.com"}]
-                   },
+                   connection_data: %ConnectionData{address: {:IP4, "host.biloxi.example.com"}},
                    encryption: nil,
                    fmt: [32],
                    port: 49_170,
@@ -282,7 +245,7 @@ defmodule ExSDP.RFCTest do
                  username: "bob",
                  session_id: 2_808_844_564,
                  session_version: 2_808_844_564,
-                 address: %FQDN{value: "host.biloxi.example.com"}
+                 address: {:IP4, "host.biloxi.example.com"}
                },
                phone_number: nil,
                session_information: nil,
@@ -319,14 +282,7 @@ defmodule ExSDP.RFCTest do
       assert expected ==
                to_string(%ExSDP{
                  attributes: [:recvonly],
-                 connection_data: %ConnectionData{
-                   addresses: [
-                     %IP4{
-                       ttl: 127,
-                       value: {224, 2, 17, 12}
-                     }
-                   ]
-                 },
+                 connection_data: %ConnectionData{ttl: 127, address: {224, 2, 17, 12}},
                  email: "j.doe@example.com (Jane Doe)",
                  media: [
                    %Media{
@@ -352,9 +308,7 @@ defmodule ExSDP.RFCTest do
                    }
                  ],
                  origin: %Origin{
-                   address: %IP4{
-                     value: {10, 47, 16, 5}
-                   },
+                   address: {10, 47, 16, 5},
                    session_id: 2_890_844_526,
                    session_version: 2_890_842_807,
                    username: "jdoe"
@@ -393,9 +347,7 @@ defmodule ExSDP.RFCTest do
                to_string(%ExSDP{
                  attributes: [],
                  bandwidth: [],
-                 connection_data: %ConnectionData{
-                   addresses: [%FQDN{value: "host.atlanta.example.com"}]
-                 },
+                 connection_data: %ConnectionData{address: {:IP4, "host.atlanta.example.com"}},
                  email: nil,
                  encryption: nil,
                  media: [
@@ -451,7 +403,7 @@ defmodule ExSDP.RFCTest do
                    }
                  ],
                  origin: %Origin{
-                   address: %FQDN{value: "host.atlanta.example.com"},
+                   address: {:IP4, "host.atlanta.example.com"},
                    session_id: 2_890_844_526,
                    session_version: 2_890_844_526,
                    username: "alice"
@@ -487,9 +439,7 @@ defmodule ExSDP.RFCTest do
                to_string(%ExSDP{
                  attributes: [],
                  bandwidth: [],
-                 connection_data: %ConnectionData{
-                   addresses: [%FQDN{value: "host.biloxi.example.com"}]
-                 },
+                 connection_data: %ConnectionData{address: {:IP4, "host.biloxi.example.com"}},
                  email: nil,
                  encryption: nil,
                  media: [
@@ -532,7 +482,7 @@ defmodule ExSDP.RFCTest do
                    username: "bob",
                    session_id: 2_808_844_564,
                    session_version: 2_808_844_564,
-                   address: %FQDN{value: "host.biloxi.example.com"}
+                   address: {:IP4, "host.biloxi.example.com"}
                  },
                  phone_number: nil,
                  session_information: nil,

--- a/test/rfc_spec_test.exs
+++ b/test/rfc_spec_test.exs
@@ -63,7 +63,7 @@ defmodule ExSDP.RFCTest do
                      ]
                    },
                    fmt: [0],
-                   ports: [49_170],
+                   port: 49_170,
                    protocol: "RTP/AVP",
                    type: :audio
                  },
@@ -84,7 +84,7 @@ defmodule ExSDP.RFCTest do
                      ]
                    },
                    fmt: [99],
-                   ports: [51_372],
+                   port: 51_372,
                    protocol: "RTP/AVP",
                    type: :video
                  }
@@ -164,7 +164,7 @@ defmodule ExSDP.RFCTest do
                    },
                    encryption: nil,
                    fmt: [0, 8, 97],
-                   ports: [49_170],
+                   port: 49_170,
                    protocol: "RTP/AVP",
                    title: nil,
                    type: :audio
@@ -188,7 +188,7 @@ defmodule ExSDP.RFCTest do
                    },
                    encryption: nil,
                    fmt: [31, 32],
-                   ports: [51_372],
+                   port: 51_372,
                    protocol: "RTP/AVP",
                    title: nil,
                    type: :video
@@ -252,7 +252,7 @@ defmodule ExSDP.RFCTest do
                    },
                    encryption: nil,
                    fmt: [0],
-                   ports: [49_174],
+                   port: 49_174,
                    protocol: "RTP/AVP",
                    title: nil,
                    type: :audio
@@ -272,7 +272,7 @@ defmodule ExSDP.RFCTest do
                    },
                    encryption: nil,
                    fmt: [32],
-                   ports: [49_170],
+                   port: 49_170,
                    protocol: "RTP/AVP",
                    title: nil,
                    type: :video
@@ -333,7 +333,7 @@ defmodule ExSDP.RFCTest do
                      attributes: [],
                      bandwidth: [],
                      fmt: [0],
-                     ports: [49_170],
+                     port: 49_170,
                      protocol: "RTP/AVP",
                      type: :audio
                    },
@@ -346,7 +346,7 @@ defmodule ExSDP.RFCTest do
                        }
                      ],
                      fmt: [99],
-                     ports: [51_372],
+                     port: 51_372,
                      protocol: "RTP/AVP",
                      type: :video
                    }
@@ -423,7 +423,7 @@ defmodule ExSDP.RFCTest do
                      bandwidth: [],
                      encryption: nil,
                      fmt: [0, 8, 97],
-                     ports: [49_170],
+                     port: 49_170,
                      protocol: "RTP/AVP",
                      title: nil,
                      type: :audio
@@ -444,7 +444,7 @@ defmodule ExSDP.RFCTest do
                      bandwidth: [],
                      encryption: nil,
                      fmt: [31, 32],
-                     ports: [51_372],
+                     port: 51_372,
                      protocol: "RTP/AVP",
                      title: nil,
                      type: :video
@@ -505,7 +505,7 @@ defmodule ExSDP.RFCTest do
                      bandwidth: [],
                      encryption: nil,
                      fmt: [0],
-                     ports: [49_174],
+                     port: 49_174,
                      protocol: "RTP/AVP",
                      title: nil,
                      type: :audio
@@ -522,7 +522,7 @@ defmodule ExSDP.RFCTest do
                      bandwidth: [],
                      encryption: nil,
                      fmt: [32],
-                     ports: [49_170],
+                     port: 49_170,
                      protocol: "RTP/AVP",
                      title: nil,
                      type: :video

--- a/test/sdp_test.exs
+++ b/test/sdp_test.exs
@@ -73,7 +73,7 @@ defmodule ExSDPTest do
         },
         encryption: %Encryption{key: nil, method: :prompt},
         fmt: [0],
-        ports: [49_170],
+        port: 49_170,
         protocol: "RTP/AVP",
         title: "Sample media title",
         type: :audio
@@ -100,7 +100,7 @@ defmodule ExSDPTest do
         },
         encryption: %Encryption{key: "key", method: :clear},
         fmt: [99],
-        ports: [51_372],
+        port: 51_372,
         protocol: "RTP/AVP",
         title: nil,
         type: :video

--- a/test/sdp_test.exs
+++ b/test/sdp_test.exs
@@ -159,7 +159,7 @@ defmodule ExSDPTest do
       a=rtpmap:99 h263-1998/90000
       c=invalid data
 
-      with reason: invalid_connection_data too_few_fields
+      with reason: too_few_fields
       """
 
       assert_raise RuntimeError, expected_message, fn ->
@@ -177,7 +177,7 @@ defmodule ExSDPTest do
       expected = """
       An error has occurred while parsing following SDP line:
       o=jdoe 2890844526 2890842807 IN
-      with reason: invalid_origin too_few_fields
+      with reason: too_few_fields
       """
 
       assert_raise RuntimeError, expected, fn ->

--- a/test/sdp_test.exs
+++ b/test/sdp_test.exs
@@ -47,14 +47,7 @@ defmodule ExSDPTest do
     bandwidth: [
       %Bandwidth{bandwidth: 256, type: :CT}
     ],
-    connection_data: %ConnectionData{
-      addresses: [
-        %ConnectionData.IP4{
-          ttl: 127,
-          value: {224, 2, 17, 12}
-        }
-      ]
-    },
+    connection_data: %ConnectionData{address: {224, 2, 17, 12}, ttl: 127},
     email: "j.doe@example.com (Jane Doe)",
     encryption: %Encryption{key: "key", method: :clear},
     media: [
@@ -63,14 +56,7 @@ defmodule ExSDPTest do
         bandwidth: [
           %Bandwidth{bandwidth: 256, type: :CT}
         ],
-        connection_data: %ConnectionData{
-          addresses: [
-            %ConnectionData.IP4{
-              ttl: 127,
-              value: {224, 2, 17, 12}
-            }
-          ]
-        },
+        connection_data: %ConnectionData{ttl: 127, address: {224, 2, 17, 12}},
         encryption: %Encryption{key: nil, method: :prompt},
         fmt: [0],
         port: 49_170,
@@ -90,14 +76,7 @@ defmodule ExSDPTest do
         bandwidth: [
           %Bandwidth{bandwidth: 256, type: :CT}
         ],
-        connection_data: %ConnectionData{
-          addresses: [
-            %ConnectionData.IP4{
-              ttl: 127,
-              value: {224, 2, 17, 12}
-            }
-          ]
-        },
+        connection_data: %ConnectionData{ttl: 127, address: {224, 2, 17, 12}},
         encryption: %Encryption{key: "key", method: :clear},
         fmt: [99],
         port: 51_372,
@@ -107,9 +86,7 @@ defmodule ExSDPTest do
       }
     ],
     origin: %Origin{
-      address: %ConnectionData.IP4{
-        value: {10, 47, 16, 5}
-      },
+      address: {10, 47, 16, 5},
       session_id: 2_890_844_526,
       session_version: 2_890_842_807,
       username: "jdoe"
@@ -182,7 +159,7 @@ defmodule ExSDPTest do
       a=rtpmap:99 h263-1998/90000
       c=invalid data
 
-      with reason: invalid_connection_data
+      with reason: invalid_connection_data too_few_fields
       """
 
       assert_raise RuntimeError, expected_message, fn ->
@@ -200,7 +177,7 @@ defmodule ExSDPTest do
       expected = """
       An error has occurred while parsing following SDP line:
       o=jdoe 2890844526 2890842807 IN
-      with reason: invalid_connection_data
+      with reason: invalid_origin too_few_fields
       """
 
       assert_raise RuntimeError, expected, fn ->

--- a/test/webrtc_test.exs
+++ b/test/webrtc_test.exs
@@ -55,7 +55,7 @@ defmodule ExSDP.WebRTCTest do
                      "92:35:B0:F7:B5:98:6D:E3:B8:7C:EA:03:84:7D:16:B6:D8:01:4C:48:61:9A:EF:DE:83:31:A0:2A:09:A9:47:92"}},
                    {:setup, :actpass},
                    {:mid, "0"},
-                   %ExSDP.Attribute.Msid{
+                   %ExSDP.Attribute.MSID{
                      app_data: "95315dd8-13a2-4e3c-952a-c57042a75dc2",
                      id: "699c4cc3-91bf-40e0-a664-a96ee2d103c2"
                    },
@@ -66,8 +66,8 @@ defmodule ExSDP.WebRTCTest do
                      params: 2,
                      payload_type: 120
                    },
-                   %ExSDP.Attribute.Fmtp{pt: 120, useinbandfec: true},
-                   %ExSDP.Attribute.Ssrc{attribute: "cname", id: 990_927_281, value: "media0"}
+                   %ExSDP.Attribute.FMTP{pt: 120, useinbandfec: true},
+                   %ExSDP.Attribute.SSRC{attribute: "cname", id: 990_927_281, value: "media0"}
                  ],
                  connection_data: [
                    %ExSDP.ConnectionData{address: {0, 0, 0, 0}, network_type: "IN"}
@@ -88,7 +88,7 @@ defmodule ExSDP.WebRTCTest do
                      "92:35:B0:F7:B5:98:6D:E3:B8:7C:EA:03:84:7D:16:B6:D8:01:4C:48:61:9A:EF:DE:83:31:A0:2A:09:A9:47:92"}},
                    {:setup, :actpass},
                    {:mid, "1"},
-                   %ExSDP.Attribute.Msid{
+                   %ExSDP.Attribute.MSID{
                      app_data: "9f80e638-16f2-4120-81b3-8b4290df3ab6",
                      id: "699c4cc3-91bf-40e0-a664-a96ee2d103c2"
                    },
@@ -99,13 +99,13 @@ defmodule ExSDP.WebRTCTest do
                      encoding: "H264",
                      payload_type: 96
                    },
-                   %ExSDP.Attribute.Fmtp{
+                   %ExSDP.Attribute.FMTP{
                      level_asymmetry_allowed: true,
                      packetization_mode: 1,
                      profile_level_id: 4_382_751,
                      pt: 96
                    },
-                   %ExSDP.Attribute.Ssrc{attribute: "cname", id: 50_301_058, value: "media1"}
+                   %ExSDP.Attribute.SSRC{attribute: "cname", id: 50_301_058, value: "media1"}
                  ],
                  connection_data: [
                    %ExSDP.ConnectionData{address: {0, 0, 0, 0}, network_type: "IN"}

--- a/test/webrtc_test.exs
+++ b/test/webrtc_test.exs
@@ -1,0 +1,131 @@
+defmodule ExSDP.WebRTCTest do
+  use ExUnit.Case
+
+  test "Parses SDP with attributes specific for WebRTC" do
+    {:ok, parsed} =
+      """
+      v=0
+      o=- 10697771362128785113 0 IN IP4 127.0.0.1
+      s=-
+      t=0 0
+      a=group:BUNDLE 0 1
+      m=audio 9 UDP/TLS/RTP/SAVPF 120
+      c=IN IP4 0.0.0.0
+      a=sendrecv
+      a=ice-ufrag:UEqK
+      a=ice-pwd:ZZ5rsux1D15c7j4nKrhYEH
+      a=ice-options:trickle
+      a=fingerprint:sha-256 92:35:B0:F7:B5:98:6D:E3:B8:7C:EA:03:84:7D:16:B6:D8:01:4C:48:61:9A:EF:DE:83:31:A0:2A:09:A9:47:92
+      a=setup:actpass
+      a=mid:0
+      a=msid:699c4cc3-91bf-40e0-a664-a96ee2d103c2 95315dd8-13a2-4e3c-952a-c57042a75dc2
+      a=rtcp-mux
+      a=rtpmap:120 OPUS/48000/2
+      a=fmtp:120 useinbandfec=1
+      a=ssrc:990927281 cname:media0
+      m=video 9 UDP/TLS/RTP/SAVPF 96
+      c=IN IP4 0.0.0.0
+      a=ice-ufrag:UEqK
+      a=ice-pwd:ZZ5rsux1D15c7j4nKrhYEH
+      a=ice-options:trickle
+      a=fingerprint:sha-256 92:35:B0:F7:B5:98:6D:E3:B8:7C:EA:03:84:7D:16:B6:D8:01:4C:48:61:9A:EF:DE:83:31:A0:2A:09:A9:47:92
+      a=setup:actpass
+      a=mid:1
+      a=msid:699c4cc3-91bf-40e0-a664-a96ee2d103c2 9f80e638-16f2-4120-81b3-8b4290df3ab6
+      a=rtcp-mux
+      a=rtcp-rsize
+      a=rtpmap:96 H264/90000
+      a=fmtp:96 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1
+      a=ssrc:50301058 cname:media1
+      """
+      |> String.replace("\n", "\r\n")
+      |> ExSDP.parse()
+
+    assert parsed == %ExSDP{
+             attributes: [group: {:BUNDLE, ["0", "1"]}],
+             media: [
+               %ExSDP.Media{
+                 attributes: [
+                   :sendrecv,
+                   {:ice_ufrag, "UEqK"},
+                   {:ice_pwd, "ZZ5rsux1D15c7j4nKrhYEH"},
+                   {:ice_options, ["trickle"]},
+                   {:fingerprint,
+                    {:sha256,
+                     "92:35:B0:F7:B5:98:6D:E3:B8:7C:EA:03:84:7D:16:B6:D8:01:4C:48:61:9A:EF:DE:83:31:A0:2A:09:A9:47:92"}},
+                   {:setup, :actpass},
+                   {:mid, "0"},
+                   %ExSDP.Attribute.Msid{
+                     app_data: "95315dd8-13a2-4e3c-952a-c57042a75dc2",
+                     id: "699c4cc3-91bf-40e0-a664-a96ee2d103c2"
+                   },
+                   :rtcp_mux,
+                   %ExSDP.Attribute.RTPMapping{
+                     clock_rate: 48_000,
+                     encoding: "OPUS",
+                     params: 2,
+                     payload_type: 120
+                   },
+                   %ExSDP.Attribute.Fmtp{pt: 120, useinbandfec: true},
+                   %ExSDP.Attribute.Ssrc{attribute: "cname", id: 990_927_281, value: "media0"}
+                 ],
+                 connection_data: [
+                   %ExSDP.ConnectionData{address: {0, 0, 0, 0}, network_type: "IN"}
+                 ],
+                 fmt: [120],
+                 port: 9,
+                 port_count: 1,
+                 protocol: "UDP/TLS/RTP/SAVPF",
+                 type: :audio
+               },
+               %ExSDP.Media{
+                 attributes: [
+                   {:ice_ufrag, "UEqK"},
+                   {:ice_pwd, "ZZ5rsux1D15c7j4nKrhYEH"},
+                   {:ice_options, ["trickle"]},
+                   {:fingerprint,
+                    {:sha256,
+                     "92:35:B0:F7:B5:98:6D:E3:B8:7C:EA:03:84:7D:16:B6:D8:01:4C:48:61:9A:EF:DE:83:31:A0:2A:09:A9:47:92"}},
+                   {:setup, :actpass},
+                   {:mid, "1"},
+                   %ExSDP.Attribute.Msid{
+                     app_data: "9f80e638-16f2-4120-81b3-8b4290df3ab6",
+                     id: "699c4cc3-91bf-40e0-a664-a96ee2d103c2"
+                   },
+                   :rtcp_mux,
+                   :rtcp_rsize,
+                   %ExSDP.Attribute.RTPMapping{
+                     clock_rate: 90_000,
+                     encoding: "H264",
+                     payload_type: 96
+                   },
+                   %ExSDP.Attribute.Fmtp{
+                     level_asymmetry_allowed: true,
+                     packetization_mode: 1,
+                     profile_level_id: 4_382_751,
+                     pt: 96
+                   },
+                   %ExSDP.Attribute.Ssrc{attribute: "cname", id: 50_301_058, value: "media1"}
+                 ],
+                 connection_data: [
+                   %ExSDP.ConnectionData{address: {0, 0, 0, 0}, network_type: "IN"}
+                 ],
+                 fmt: [96],
+                 port: 9,
+                 port_count: 1,
+                 protocol: "UDP/TLS/RTP/SAVPF",
+                 type: :video
+               }
+             ],
+             origin: %ExSDP.Origin{
+               address: {127, 0, 0, 1},
+               network_type: "IN",
+               session_id: 10_697_771_362_128_785_113,
+               session_version: 0
+             },
+             session_name: "-",
+             timing: %ExSDP.Timing{start_time: 0, stop_time: 0},
+             version: 0
+           }
+  end
+end


### PR DESCRIPTION
* adds structs for: msid, fmtp, ssrc
* adds more known attributes
* simplifies ConnectionData struct 
* introduces port_count and adress_count instead of passing all ports or addresses (in media and connection-data) 
* unifies errors from #8 to the form of `{:error, reason}` instead of `{:error, {:invalid_origin, reason}}`

