### PR TITLE
Add support for extmap attribute

### DIFF
--- a/lib/ex_sdp/attribute.ex
+++ b/lib/ex_sdp/attribute.ex
@@ -5,7 +5,7 @@ defmodule ExSDP.Attribute do
   use Bunch.Typespec
   use Bunch.Access
 
-  alias __MODULE__.{RTPMapping, MSID, FMTP, SSRC, Group}
+  alias __MODULE__.{RTPMapping, MSID, FMTP, SSRC, Group, Extmap}
 
   @type hash_function :: :sha1 | :sha224 | :sha256 | :sha384 | :sha512
   @type setup_value :: :active | :passive | :actpass | :holdconn
@@ -47,6 +47,7 @@ defmodule ExSDP.Attribute do
           | __MODULE__.FMTP.t()
           | __MODULE__.SSRC.t()
           | __MODULE__.Group.t()
+          | __MODULE__.Extmap.t()
           | cat()
           | charset()
           | keywds()
@@ -89,6 +90,7 @@ defmodule ExSDP.Attribute do
   defp do_parse("fmtp", value, _opts), do: FMTP.parse(value)
   defp do_parse("ssrc", value, _opts), do: SSRC.parse(value)
   defp do_parse("group", value, _opts), do: Group.parse(value)
+  defp do_parse("extmap", value, _opts), do: Extmap.parse(value)
   defp do_parse("cat", value, _opts), do: {:ok, {:cat, value}}
   defp do_parse("charset", value, _opts), do: {:ok, {:charset, value}}
   defp do_parse("keywds", value, _opts), do: {:ok, {:keywds, value}}

--- a/lib/ex_sdp/attribute/extmap.ex
+++ b/lib/ex_sdp/attribute/extmap.ex
@@ -1,0 +1,94 @@
+defmodule ExSDP.Attribute.Extmap do
+  @moduledoc """
+  This module represents extmap (RFC 8285).
+  """
+  alias ExSDP.Utils
+
+  @enforce_keys [:id, :uri]
+  defstruct @enforce_keys ++ [direction: nil, attributes: []]
+
+  @type extension_id :: 1..14
+  @type direction :: :sendonly | :recvonly | :sendrecv | :inactive | nil
+
+  @type t :: %__MODULE__{
+          id: extension_id(),
+          direction: direction(),
+          uri: String.t(),
+          attributes: [String.t()]
+        }
+
+  @typedoc """
+  Key that can be used for searching this attribute using `ExSDP.Media.get_attribute/2`.
+  """
+  @type attr_key :: :extmap
+
+  @typedoc """
+  Reason of parsing failure.
+  """
+  @type reason :: :invalid_extmap | :invalid_id | :invalid_direction | :invalid_uri
+
+  @valid_directions ["sendonly", "recvonly", "sendrecv", "inactive"]
+
+  @spec parse(binary()) :: {:ok, t()} | {:error, reason()}
+  def parse(extmap) do
+    with [id_direction, uri_attributes] <- String.split(extmap, " ", parts: 2),
+         {:ok, {id, direction}} <- parse_id_direction(id_direction),
+         {:ok, {uri, attributes}} <- parse_uri_attributes(uri_attributes) do
+      {:ok, %__MODULE__{id: id, direction: direction, uri: uri, attributes: attributes}}
+    else
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :invalid_extmap}
+    end
+  end
+
+  defp parse_id_direction(id_direction) do
+    case String.split(id_direction, "/") do
+      [id, direction] ->
+        with {:ok, id} <- Utils.parse_numeric_string(id),
+             {:ok, direction} <- parse_direction(direction) do
+          {:ok, {id, direction}}
+        else
+          {:error, :string_nan} -> {:error, :invalid_id}
+          {:error, reason} -> {:error, reason}
+        end
+
+      [id] ->
+        case Utils.parse_numeric_string(id) do
+          {:ok, id} -> {:ok, {id, nil}}
+          _ -> {:error, :invalid_id}
+        end
+
+      _ ->
+        {:error, :invalid_extmap}
+    end
+  end
+
+  defp parse_uri_attributes(uri_attributes) do
+    case String.split(uri_attributes, " ") do
+      [uri | attributes] -> {:ok, {uri, attributes}}
+      _ -> {:error, :invalid_uri}
+    end
+  end
+
+  defp parse_direction(direction) when direction in @valid_directions,
+    do: {:ok, String.to_atom(direction)}
+
+  defp parse_direction(_unknown), do: {:error, :invalid_direction}
+end
+
+defimpl String.Chars, for: ExSDP.Attribute.Extmap do
+  alias ExSDP.Attribute.Extmap
+
+  def to_string(%Extmap{id: id, direction: direction, uri: uri, attributes: attributes}) do
+    maybe_direction =
+      if direction == nil do
+        ""
+      else
+        "/#{Atom.to_string(direction)}"
+      end
+
+    attributes = Enum.join(attributes, " ")
+
+    "extmap:#{id}#{maybe_direction} #{uri} #{attributes}" |> String.trim()
+  end
+end

--- a/lib/ex_sdp/attribute/extmap.ex
+++ b/lib/ex_sdp/attribute/extmap.ex
@@ -80,12 +80,7 @@ defimpl String.Chars, for: ExSDP.Attribute.Extmap do
   alias ExSDP.Attribute.Extmap
 
   def to_string(%Extmap{id: id, direction: direction, uri: uri, attributes: attributes}) do
-    maybe_direction =
-      if direction == nil do
-        ""
-      else
-        "/#{Atom.to_string(direction)}"
-      end
+    maybe_direction = if direction == nil, do: "", else: "/#{Atom.to_string(direction)}"
 
     attributes = Enum.join(attributes, " ")
 

--- a/lib/ex_sdp/media.ex
+++ b/lib/ex_sdp/media.ex
@@ -14,7 +14,7 @@ defmodule ExSDP.Media do
     Encryption
   }
 
-  alias ExSDP.Attribute.{RTPMapping, MSID, FMTP, SSRC, Group}
+  alias ExSDP.Attribute.{RTPMapping, MSID, FMTP, SSRC, Group, Extmap}
 
   @enforce_keys [:type, :port, :protocol, :fmt]
   defstruct @enforce_keys ++
@@ -54,7 +54,8 @@ defmodule ExSDP.Media do
     :msid => MSID,
     :fmtp => FMTP,
     :ssrc => SSRC,
-    :group => Group
+    :group => Group,
+    :extmap => Extmap
   }
 
   @spec new(

--- a/test/ex_sdp/attribute/extmap_test.exs
+++ b/test/ex_sdp/attribute/extmap_test.exs
@@ -1,0 +1,131 @@
+defmodule ExSDP.Attribute.ExtmapTest do
+  use ExUnit.Case
+
+  alias ExSDP.Attribute.Extmap
+
+  @test_uri "http://example.com/082005/ext.htm#xmeta"
+
+  describe "Extmap parser" do
+    test "parses minimal extmap" do
+      extmap = "2 #{@test_uri}"
+
+      expected = %Extmap{
+        id: 2,
+        uri: @test_uri,
+        direction: nil,
+        attributes: []
+      }
+
+      assert {:ok, expected} == Extmap.parse(extmap)
+    end
+
+    test "parses extmap with direction" do
+      valid_directions = [:sendonly, :recvonly, :sendrecv, :inactive]
+
+      Enum.each(valid_directions, fn direction ->
+        extmap = "2/#{Atom.to_string(direction)} #{@test_uri}"
+
+        expected = %Extmap{
+          id: 2,
+          uri: @test_uri,
+          direction: direction,
+          attributes: []
+        }
+
+        assert {:ok, expected} == Extmap.parse(extmap)
+      end)
+    end
+
+    test "parses extmap with attributes" do
+      extmap = "2 #{@test_uri} unsigned short int"
+
+      expected = %Extmap{
+        id: 2,
+        uri: @test_uri,
+        direction: nil,
+        attributes: ["unsigned", "short", "int"]
+      }
+
+      assert {:ok, expected} == Extmap.parse(extmap)
+    end
+
+    test "parses extmap with direction and attributes" do
+      extmap = "2/sendrecv #{@test_uri} unsigned short int"
+
+      expected = %Extmap{
+        id: 2,
+        uri: @test_uri,
+        direction: :sendrecv,
+        attributes: ["unsigned", "short", "int"]
+      }
+
+      assert {:ok, expected} == Extmap.parse(extmap)
+    end
+
+    test "returns an error when there is invalid id" do
+      extmap = "two/sendrecv #{@test_uri} unsigned short int"
+      assert {:error, :invalid_id} = Extmap.parse(extmap)
+
+      extmap = "/sendrecv #{@test_uri} unsigned short int"
+      assert {:error, :invalid_id} = Extmap.parse(extmap)
+
+      extmap = "sendrecv #{@test_uri} unsigned short int"
+      assert {:error, :invalid_id} = Extmap.parse(extmap)
+    end
+
+    test "returns an error when there is invalid direction" do
+      extmap = "2/invalid #{@test_uri} unsigned short int"
+      assert {:error, :invalid_direction} = Extmap.parse(extmap)
+
+      extmap = "2/ #{@test_uri} unsigned short int"
+      assert {:error, :invalid_direction} = Extmap.parse(extmap)
+    end
+
+    test "returns an error when there is invalid schema" do
+      extmap = "invalidschema"
+      assert {:error, :invalid_extmap} = Extmap.parse(extmap)
+    end
+  end
+
+  describe "Extmap serializer" do
+    test "serializes minimal extmap" do
+      extmap = %Extmap{
+        id: 1,
+        uri: @test_uri
+      }
+
+      assert "#{extmap}" == "extmap:1 #{@test_uri}"
+    end
+
+    test "serializes extmap with direction" do
+      extmap = %Extmap{
+        id: 1,
+        uri: @test_uri,
+        direction: :sendrecv
+      }
+
+      assert "#{extmap}" == "extmap:1/sendrecv #{@test_uri}"
+    end
+
+    test "serializes extmap with attributes" do
+      extmap = %Extmap{
+        id: 1,
+        uri: @test_uri,
+        attributes: ["unsigned", "short", "int"]
+      }
+
+      assert "#{extmap}" == "extmap:1 #{@test_uri} unsigned short int"
+    end
+
+    test "serializes extmap with direction and attributes" do
+      extmap = %Extmap{
+        id: 1,
+        uri: @test_uri,
+        direction: :sendrecv,
+        attributes: ["unsigned", "short", "int"]
+      }
+
+      assert "#{extmap}" == "extmap:1/sendrecv #{@test_uri} unsigned short int"
+    end
+  end
+end

--- a/test/ex_sdp/media_test.exs
+++ b/test/ex_sdp/media_test.exs
@@ -291,6 +291,9 @@ defmodule ExSDP.MediaTest do
 
       assert msid == Media.get_attribute(media, MSID)
       assert msid == Media.get_attribute(media, :msid)
+
+      assert extmap == Media.get_attribute(media, Extmap)
+      assert extmap == Media.get_attribute(media, :extmap)
     end
   end
 end

--- a/test/ex_sdp/media_test.exs
+++ b/test/ex_sdp/media_test.exs
@@ -12,7 +12,7 @@ defmodule ExSDP.MediaTest do
     Timing
   }
 
-  alias ExSDP.Attribute.{FMTP, MSID, RTPMapping, SSRC}
+  alias ExSDP.Attribute.{FMTP, MSID, RTPMapping, SSRC, Extmap}
 
   describe "Media parser" do
     test "processes valid media description" do
@@ -265,12 +265,20 @@ defmodule ExSDP.MediaTest do
 
       msid = %MSID{id: "DycBRAGTwt75ESYihb03FsVWVs8sSdIkhTqN"}
 
+      extmap = %Extmap{
+        id: 1,
+        uri: "http://example.com/082005/ext.htm#xmeta",
+        direction: :recvonly,
+        attributes: ["unsigned", "short", "int"]
+      }
+
       media =
         Media.new(:video, 51_372, "RTP/AVP", [99])
         |> Media.add_attribute(rtpmap)
         |> Media.add_attribute(ssrc)
         |> Media.add_attribute(fmtp)
         |> Media.add_attribute(msid)
+        |> Media.add_attribute(extmap)
 
       assert rtpmap == Media.get_attribute(media, RTPMapping)
       assert rtpmap == Media.get_attribute(media, :rtpmap)


### PR DESCRIPTION
Adds `ExSDP.Attribute.Extmap` module which allows to parse and serialize extmap