### PR TITLE
Handle spaces between parameters in FMTP attributes & accept params: sprop-maxcapturerate, maxptime, ptime

### DIFF
--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -98,11 +98,13 @@ defmodule ExSDP.Attribute.FMTP do
 
   @spec parse(binary()) :: {:ok, t()} | {:error, reason()}
   def parse(fmtp) do
-    with [pt_string, rest] <- String.split(fmtp, " "),
+    with [pt_string | rest] <- String.split(fmtp, " "),
          {:ok, pt} <- Utils.parse_payload_type(pt_string) do
-      rest
-      |> String.split(";")
-      |> do_parse(%__MODULE__{pt: pt})
+
+      params = for param <- rest do String.replace(param, ";", "") end
+
+      do_parse(params, %__MODULE__{pt: pt})
+
     else
       {:error, _reason} = err -> err
       _other -> :invalid_fmtp

--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -32,6 +32,9 @@ defmodule ExSDP.Attribute.FMTP do
                 # OPUS
                 :maxaveragebitrate,
                 :maxplaybackrate,
+                :sprop_maxcapturerate,
+                :maxptime,
+                :ptime,
                 :minptime,
                 :stereo,
                 :cbr,
@@ -64,6 +67,9 @@ defmodule ExSDP.Attribute.FMTP do
           # OPUS
           maxaveragebitrate: non_neg_integer() | nil,
           maxplaybackrate: non_neg_integer() | nil,
+          sprop_maxcapturerate: non_neg_integer() | nil,
+          maxptime: non_neg_integer() | nil,
+          ptime: non_neg_integer() | nil,
           minptime: non_neg_integer() | nil,
           stereo: boolean() | nil,
           cbr: boolean() | nil,
@@ -166,6 +172,21 @@ defmodule ExSDP.Attribute.FMTP do
   defp parse_param(["maxplaybackrate=" <> maxplaybackrate | rest], fmtp) do
     with {:ok, value} <- Utils.parse_numeric_string(maxplaybackrate),
          do: {rest, %{fmtp | maxplaybackrate: value}}
+  end
+
+  defp parse_param(["sprop-maxcapturerate=" <> sprop_maxcapturerate | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(sprop_maxcapturerate),
+          do: {rest, %{fmtp | sprop_maxcapturerate: value}}
+  end
+
+  defp parse_param(["maxptime=" <> maxptime | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(maxptime),
+         do: {rest, %{fmtp | maxptime: value}}
+  end
+
+  defp parse_param(["ptime=" <> ptime | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(ptime),
+         do: {rest, %{fmtp | ptime: value}}
   end
 
   defp parse_param(["minptime=" <> minptime | rest], fmtp) do
@@ -288,6 +309,9 @@ defimpl String.Chars, for: ExSDP.Attribute.FMTP do
         # OPUS
         Serializer.maybe_serialize("maxaveragebitrate", fmtp.maxaveragebitrate),
         Serializer.maybe_serialize("maxplaybackrate", fmtp.maxplaybackrate),
+        Serializer.maybe_serialize("sprop_maxcapturerate", fmtp.sprop_maxcapturerate),
+        Serializer.maybe_serialize("maxptime", fmtp.maxptime),
+        Serializer.maybe_serialize("ptime", fmtp.ptime),
         Serializer.maybe_serialize("minptime", fmtp.minptime),
         Serializer.maybe_serialize("stereo", fmtp.stereo),
         Serializer.maybe_serialize("cbr", fmtp.cbr),

--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -106,11 +106,12 @@ defmodule ExSDP.Attribute.FMTP do
   def parse(fmtp) do
     with [pt_string | rest] <- String.split(fmtp, " "),
          {:ok, pt} <- Utils.parse_payload_type(pt_string) do
-
-      params = for param <- rest do String.replace(param, ";", "") end
+      params =
+        for param <- rest do
+          String.replace(param, ";", "")
+        end
 
       do_parse(params, %__MODULE__{pt: pt})
-
     else
       {:error, _reason} = err -> err
       _other -> :invalid_fmtp
@@ -176,7 +177,7 @@ defmodule ExSDP.Attribute.FMTP do
 
   defp parse_param(["sprop-maxcapturerate=" <> sprop_maxcapturerate | rest], fmtp) do
     with {:ok, value} <- Utils.parse_numeric_string(sprop_maxcapturerate),
-          do: {rest, %{fmtp | sprop_maxcapturerate: value}}
+         do: {rest, %{fmtp | sprop_maxcapturerate: value}}
   end
 
   defp parse_param(["maxptime=" <> maxptime | rest], fmtp) do

--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -104,14 +104,13 @@ defmodule ExSDP.Attribute.FMTP do
 
   @spec parse(binary()) :: {:ok, t()} | {:error, reason()}
   def parse(fmtp) do
-    with [pt_string | rest] <- String.split(fmtp, " "),
-         {:ok, pt} <- Utils.parse_payload_type(pt_string) do
-      params =
-        for param <- rest do
-          String.replace(param, ";", "")
-        end
-
-      do_parse(params, %__MODULE__{pt: pt})
+    with [pt_string, rest] <- String.split(fmtp, " ", parts: 2),
+             {:ok, pt} <- Utils.parse_payload_type(pt_string) do
+      rest
+      |> String.split(";")
+      # remove leading whitespaces
+      |> Enum.map(&String.trim(&1))
+      |> do_parse(%__MODULE__{pt: pt})
     else
       {:error, _reason} = err -> err
       _other -> :invalid_fmtp

--- a/test/ex_sdp/attribute/fmtp_test.exs
+++ b/test/ex_sdp/attribute/fmtp_test.exs
@@ -55,6 +55,35 @@ defmodule ExSDP.Attribute.FMTPTest do
       assert {:ok, expected} == FMTP.parse(fmtp)
     end
 
+    test "parses fmtp with spaces after semi-colons" do
+      fmtp = "117 maxplaybackrate=16000; maxaveragebitrate=24000; cbr=0; useinbandfec=0; usedtx=0"
+
+      expected = %FMTP{
+        pt: 117,
+        maxplaybackrate: 16000,
+        maxaveragebitrate: 24000,
+        cbr: false,
+        usedtx: false,
+        useinbandfec: false
+      }
+
+      assert {:ok, expected} == FMTP.parse(fmtp)
+    end
+
+    test "parses fmtp with ptime, maxptime, and sprop-maxcapturerate parameters" do
+      fmtp = "121 ptime=20;maxptime=60;cbr=0;sprop-maxcapturerate=16000"
+
+      expected = %FMTP{
+        pt: 117,
+        ptime: 20,
+        maxptime: 60,
+        cbr: false,
+        sprop_maxcapturerate: 16000
+      }
+
+      assert {:ok, expected} = FMTP.parse(fmtp)
+    end
+
     test "returns an error when DTMF tone is too big" do
       fmtp = "100 0-15,256"
       assert {:error, :invalid_dtmf_tones} = FMTP.parse(fmtp)


### PR DESCRIPTION
So I'm working with a VoIP device and I'm tinkering around with getting audio out of it. I've worked out what I need to do for the SIP signalling, but when I attempted to parse the SDP payload that the device delivers (when only using OPUS on said device) ExSDP throws a match error. 

The device is providing the following FMTP 'line' if you will:
`a=fmtp:121 maxplaybackrate=16000; sprop-maxcapturerate=16000; maxptime=20; ptime=20; maxaveragebitrate=24000; cbr=0; useinbandfec=0; usedtx=0`

I ran into two issues in my use case:
1. The FMTP parser simply did not have definitions for the parameters supplied
2. when I added them, I still got match errors, so I changed the FMTP parse/1 function so it can accept many parameters. 

This is my first PR to a serious project, so I'd love some general pointers as well. Thanks in Advance!