### PR TITLE
fix parsing type and orient attributes

### DIFF
--- a/lib/ex_sdp/attribute.ex
+++ b/lib/ex_sdp/attribute.ex
@@ -135,8 +135,11 @@ defmodule ExSDP.Attribute do
 
   defp parse_orient(orient) do
     case orient do
-      string when string in ["portrait", "landscape", "seascape"] -> {:ok, {:orient, String.to_atom(string)}}
-      _invalid_orient -> {:error, :invalid_orient}
+      string when string in ["portrait", "landscape", "seascape"] ->
+        {:ok, {:orient, String.to_atom(string)}}
+
+      _invalid_orient ->
+        {:error, :invalid_orient}
     end
   end
 

--- a/lib/ex_sdp/attribute.ex
+++ b/lib/ex_sdp/attribute.ex
@@ -135,7 +135,7 @@ defmodule ExSDP.Attribute do
 
   defp parse_orient(orient) do
     case orient do
-      string when string in ["portrait", "landscape", "seascape"] -> String.to_atom(string)
+      string when string in ["portrait", "landscape", "seascape"] -> {:ok, {:orient, String.to_atom(string)}}
       _invalid_orient -> {:error, :invalid_orient}
     end
   end
@@ -143,7 +143,7 @@ defmodule ExSDP.Attribute do
   defp parse_type(type) do
     case type do
       string when string in ["broadcast", "meeting", "moderated", "test", "H332"] ->
-        String.to_atom(string)
+        {:ok, {:type, String.to_atom(string)}}
 
       _invalid_type ->
         {:error, :invalid_type}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExSDP.MixProject do
   use Mix.Project
 
-  @version "0.10.0"
+  @version "0.10.1"
   @github_url "https://github.com/membraneframework/ex_sdp"
 
   def project do


### PR DESCRIPTION
I've encountered issues using v.0.10 and found some inconsistencies in the data format returned from parsing functions. In my case problem was with `:type` parsing but I've found that `:orient` is also returned wrongly.
