### PR TITLE
Add TIAS bandwidth type

### DIFF
--- a/lib/ex_sdp/bandwidth.ex
+++ b/lib/ex_sdp/bandwidth.ex
@@ -15,9 +15,9 @@ defmodule ExSDP.Bandwidth do
           bandwidth: non_neg_integer()
         }
 
-  @type type :: :CT | :AS
+  @type type :: :CT | :AS | :TIAS
 
-  @supported_types ["CT", "AS"]
+  @supported_types ["CT", "AS", "TIAS"]
 
   @spec parse(binary()) :: {:ok, t()} | {:error, :invalid_bandwidth}
   def parse(bandwidth) do

--- a/test/ex_sdp/bandwidth_test.exs
+++ b/test/ex_sdp/bandwidth_test.exs
@@ -9,6 +9,11 @@ defmodule ExSDP.BandwidthTest do
       assert %Bandwidth{type: :CT, bandwidth: 128} == result
     end
 
+    test "parse TIAS bandwidth type" do
+      assert {:ok, result} = Bandwidth.parse("TIAS:256000")
+      assert %Bandwidth{type: :TIAS, bandwidth: 256000} == result
+    end
+
     test "returns error when property is invalid" do
       assert {:error, :invalid_bandwidth} == Bandwidth.parse("gibberish")
     end

--- a/test/ex_sdp/bandwidth_test.exs
+++ b/test/ex_sdp/bandwidth_test.exs
@@ -11,7 +11,7 @@ defmodule ExSDP.BandwidthTest do
 
     test "parse TIAS bandwidth type" do
       assert {:ok, result} = Bandwidth.parse("TIAS:256000")
-      assert %Bandwidth{type: :TIAS, bandwidth: 256000} == result
+      assert %Bandwidth{type: :TIAS, bandwidth: 256_000} == result
     end
 
     test "returns error when property is invalid" do


### PR DESCRIPTION
Add TIAS support for sdp parsing. 

I have the following sdp, which parsing is failed with ex_sdp, since TIAS isn't accepted:
```
v=0
o=- 3917959131 3917959131 IN IP4 192.168.1.95
s=pjmedia
b=AS:352
t=0 0
a=X-nat:0
m=audio 4008 RTP/AVP 8 0 18 101
c=IN IP4 192.168.1.95
b=TIAS:64000
a=rtcp:4009 IN IP4 192.168.1.95
a=sendrecv
a=rtpmap:8 PCMA/8000
a=rtpmap:0 PCMU/8000
a=rtpmap:18 G729/8000
a=rtpmap:101 telephone-event/8000
a=fmtp:101 0-16
a=ssrc:2014082431 cname:04970815321b4d3f
m=video 4010 RTP/AVP 99
c=IN IP4 192.168.1.95
b=TIAS:256000
a=rtcp:4011 IN IP4 192.168.1.95
a=sendrecv
a=rtpmap:99 H264/90000
a=fmtp:99 profile-level-id=42e01e; packetization-mode=1
a=ssrc:277103621 cname:04970815321b4d3f
a=rtcp-fb:* nack pli

```