### PR TITLE
Handle media attribute parsing without trailing new lines

### DIFF
--- a/lib/ex_sdp/media.ex
+++ b/lib/ex_sdp/media.ex
@@ -103,6 +103,8 @@ defmodule ExSDP.Media do
   @spec parse_optional([binary()], t()) :: {:ok, {[binary()], t()}} | {:error, atom()}
   def parse_optional(lines, media)
 
+  def parse_optional([], media), do: {:ok, {[""], finalize_optional_parsing(media)}}
+
   def parse_optional([""], media), do: {:ok, {[""], finalize_optional_parsing(media)}}
 
   def parse_optional(["" | rest], media),


### PR DESCRIPTION
Fixes a bug where a SDP offer without a trailing new line will fail to parse because the `Media.parse_optional/2` function expects an array with a trailing empty string, eg: `["a=foo", "a=bar", ""]`. Now it will handle `["a=foo", "b=bar"]` too.
