### PR TITLE
Add AAC fmtp

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The package can be installed by adding `ex_sdp` to your list of dependencies in 
 ```elixir
 def deps do
   [
-    {:ex_sdp, "~> 1.0"}
+    {:ex_sdp, "~> 1.1"}
   ]
 end
 ```

--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -13,7 +13,7 @@ defmodule ExSDP.Attribute.FMTP do
   * Telephone Events (RFC 4733)
   * RED (RFC 2198)
   * G.722.1 (RFC 5577)
-
+  * AAC (RFC 3640)
   are currently supported.
   """
 
@@ -71,6 +71,23 @@ defmodule ExSDP.Attribute.FMTP do
                 :redundant_payloads,
                 # G7221
                 :bitrate,
+                # AAC
+                :stream_type,
+                :config,
+                :mode,
+                :objecttype,
+                :constantsize,
+                :constantduration,
+                :maxdisplacement,
+                :de_interleavebuffersize,
+                :sizelength,
+                :indexlength,
+                :indexdeltalength,
+                :ctsdeltalength,
+                :dtsdeltalength,
+                :randomaccessindication,
+                :streamstateindication,
+                :auxillarydatasizelength,
                 unknown: []
               ]
 
@@ -121,6 +138,23 @@ defmodule ExSDP.Attribute.FMTP do
           redundant_payloads: [RTPMapping.payload_type_t()] | nil,
           # G7221
           bitrate: non_neg_integer() | nil,
+          # AAC
+          stream_type: non_neg_integer() | nil,
+          config: binary() | nil,
+          mode: String.t() | nil,
+          objecttype: non_neg_integer() | nil,
+          constantsize: non_neg_integer() | nil,
+          constantduration: non_neg_integer() | nil,
+          maxdisplacement: non_neg_integer() | nil,
+          de_interleavebuffersize: non_neg_integer() | nil,
+          sizelength: non_neg_integer() | nil,
+          indexlength: non_neg_integer() | nil,
+          indexdeltalength: non_neg_integer() | nil,
+          ctsdeltalength: non_neg_integer() | nil,
+          dtsdeltalength: non_neg_integer() | nil,
+          randomaccessindication: boolean() | nil,
+          streamstateindication: non_neg_integer() | nil,
+          auxillarydatasizelength: non_neg_integer() | nil,
           # params that are currently not supported
           unknown: [String.t()]
         }
@@ -152,7 +186,7 @@ defmodule ExSDP.Attribute.FMTP do
       |> Enum.map(&String.trim(&1))
       |> do_parse(%__MODULE__{pt: pt})
     else
-      fmtp: _other -> :invalid_fmtp
+      fmtp: _other -> {:error, :invalid_fmtp}
       pt: {:error, _reason} = err -> err
     end
   end
@@ -335,6 +369,11 @@ defmodule ExSDP.Attribute.FMTP do
   defp parse_param(["bitrate=" <> value | rest], fmtp) do
     with {:ok, value} <- Utils.parse_numeric_string(value), do: {rest, %{fmtp | bitrate: value}}
   end
+
+  # defp parse_param(["streamtype=" <> value | rest], fmtp) do
+  # with {:ok, value} <- Utils.parse_numeric_string(value),
+  # do: {rest, %{fmtp | repair_window: value}}
+  # end
 
   defp parse_param([head | rest] = params, fmtp) do
     # this is for non-key-value parameters as `key=value` format is not mandatory

--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -141,7 +141,7 @@ defmodule ExSDP.Attribute.FMTP do
           # AAC
           stream_type: non_neg_integer() | nil,
           config: binary() | nil,
-          mode: String.t() | nil,
+          mode: :generic | :CELP_cbr | :CELP_vbr | :AAC_lbr | :AAC_hbr | nil,
           objecttype: non_neg_integer() | nil,
           constantsize: non_neg_integer() | nil,
           constantduration: non_neg_integer() | nil,
@@ -370,10 +370,95 @@ defmodule ExSDP.Attribute.FMTP do
     with {:ok, value} <- Utils.parse_numeric_string(value), do: {rest, %{fmtp | bitrate: value}}
   end
 
-  # defp parse_param(["streamtype=" <> value | rest], fmtp) do
-  # with {:ok, value} <- Utils.parse_numeric_string(value),
-  # do: {rest, %{fmtp | repair_window: value}}
-  # end
+  defp parse_param(["streamtype=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | streamtype: value}}
+  end
+
+  defp parse_param(["streamtype=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | streamtype: value}}
+  end
+
+  defp parse_param(["streamtype=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | streamtype: value}}
+  end
+
+  defp parse_param(["config=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_config(value),
+         do: {rest, %{fmtp | config: value}}
+  end
+
+  defp parse_param(["mode=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_mode(value),
+         do: {rest, %{fmtp | mode: value}}
+  end
+
+  defp parse_param(["objecttype=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | objecttype: value}}
+  end
+
+  defp parse_param(["constantsize=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | constantsize: value}}
+  end
+
+  defp parse_param(["constantduration=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | constantduration: value}}
+  end
+
+  defp parse_param(["maxdisplacement=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | maxdisplacement: value}}
+  end
+
+  defp parse_param(["de-interleavebuffersize=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | de_interleavebuffersize: value}}
+  end
+
+  defp parse_param(["sizelength=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | sizelength: value}}
+  end
+
+  defp parse_param(["indexlength=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | indexlength: value}}
+  end
+
+  defp parse_param(["indexdeltalength=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | indexdeltalength: value}}
+  end
+
+  defp parse_param(["ctsdeltalength=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | ctsdeltalength: value}}
+  end
+
+  defp parse_param(["dtsdeltalength=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | dtsdeltalength: value}}
+  end
+
+  defp parse_param(["randomaccessindication=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_bool_string(value),
+         do: {rest, %{fmtp | randomaccessindication: value}}
+  end
+
+  defp parse_param(["streamstateindication=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | streamstateindication: value}}
+  end
+
+  defp parse_param(["auxillarydatasizelength=" <> value | rest], fmtp) do
+    with {:ok, value} <- Utils.parse_numeric_string(value),
+         do: {rest, %{fmtp | auxillarydatasizelength: value}}
+  end
 
   defp parse_param([head | rest] = params, fmtp) do
     # this is for non-key-value parameters as `key=value` format is not mandatory

--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -72,7 +72,7 @@ defmodule ExSDP.Attribute.FMTP do
                 # G7221
                 :bitrate,
                 # AAC
-                :stream_type,
+                :streamtype,
                 :config,
                 :mode,
                 :objecttype,
@@ -139,7 +139,7 @@ defmodule ExSDP.Attribute.FMTP do
           # G7221
           bitrate: non_neg_integer() | nil,
           # AAC
-          stream_type: non_neg_integer() | nil,
+          streamtype: non_neg_integer() | nil,
           config: binary() | nil,
           mode: :generic | :CELP_cbr | :CELP_vbr | :AAC_lbr | :AAC_hbr | nil,
           objecttype: non_neg_integer() | nil,
@@ -368,16 +368,6 @@ defmodule ExSDP.Attribute.FMTP do
 
   defp parse_param(["bitrate=" <> value | rest], fmtp) do
     with {:ok, value} <- Utils.parse_numeric_string(value), do: {rest, %{fmtp | bitrate: value}}
-  end
-
-  defp parse_param(["streamtype=" <> value | rest], fmtp) do
-    with {:ok, value} <- Utils.parse_numeric_string(value),
-         do: {rest, %{fmtp | streamtype: value}}
-  end
-
-  defp parse_param(["streamtype=" <> value | rest], fmtp) do
-    with {:ok, value} <- Utils.parse_numeric_string(value),
-         do: {rest, %{fmtp | streamtype: value}}
   end
 
   defp parse_param(["streamtype=" <> value | rest], fmtp) do

--- a/lib/ex_sdp/utils.ex
+++ b/lib/ex_sdp/utils.ex
@@ -147,4 +147,25 @@ defmodule ExSDP.Utils do
       end
     end)
   end
+
+  @spec parse_mode(binary()) ::
+          {:error, :invalid_mode} | {:ok, :generic | :CELP_cbr | :CELP_vbr | :AAC_lbr | :AAC_hbr}
+  def parse_mode(mode_string) do
+    case mode_string do
+      "generic" -> {:ok, :generic}
+      "CELP-cbr" -> {:ok, :CELP_cbr}
+      "CELP-vbr" -> {:ok, :CELP_vbr}
+      "AAC-lbr" -> {:ok, :AAC_lbr}
+      "AAC-hbr" -> {:ok, :AAC_hbr}
+      _other -> {:error, :invalid_mode}
+    end
+  end
+
+  @spec parse_config(binary()) :: {:error, :invalid_config} | {:ok, binary()}
+  def parse_config(config_string) do
+    case Base.decode16(config_string) do
+      {:ok, config} -> {:ok, config}
+      :error -> {:error, :invalid_config}
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExSDP.MixProject do
   use Mix.Project
 
-  @version "1.0.1"
+  @version "1.1.0"
   @github_url "https://github.com/membraneframework/ex_sdp"
 
   def project do


### PR DESCRIPTION
I think it's worth considering whether we could implement parsing fmtp params more concisely, than having a separate function call for each one