### PR TITLE
fix: removed empty string 

### DIFF
--- a/lib/ex_sdp/attribute/fmtp.ex
+++ b/lib/ex_sdp/attribute/fmtp.ex
@@ -184,6 +184,7 @@ defmodule ExSDP.Attribute.FMTP do
       |> String.split(";")
       # remove leading whitespaces
       |> Enum.map(&String.trim(&1))
+      |> Enum.reject(&(&1 == ""))
       |> do_parse(%__MODULE__{pt: pt})
     else
       fmtp: _other -> {:error, :invalid_fmtp}


### PR DESCRIPTION
After splitting the fmtp attribute, the resulting list contains a trailing empty string:
```
["profile-level-id=15", " streamtype=5", " mode=AAC-hbr", " config=1408",
 "SizeLength=13", " IndexLength=3", " IndexDeltaLength=3", " Profile=1", ""]
```
hence causing the recursion to continue therefore throwing  `{:error, {:invalid_dtmf_tones, "m=audio 0 RTP/AVP 104"}}`. This PR filters the empty string out.