### PR TITLE
trim rtcp feedback

### DIFF
--- a/lib/ex_sdp/attribute/rtcp_feedback.ex
+++ b/lib/ex_sdp/attribute/rtcp_feedback.ex
@@ -54,6 +54,7 @@ defmodule ExSDP.Attribute.RTCPFeedback do
   end
 
   defp parse_feedback_type(fb_type_string) do
+    fb_type_string = String.trim(fb_type_string)
     Map.get(@fb_type_mapping, fb_type_string, fb_type_string)
   end
 

--- a/test/ex_sdp/attribute/rtcp_feedback_test.exs
+++ b/test/ex_sdp/attribute/rtcp_feedback_test.exs
@@ -21,6 +21,10 @@ defmodule ExSDP.Attribute.RTCPFeedbackTest do
                {:ok, %RTCPFeedback{pt: 98, feedback_type: :pli}}
     end
 
+    test "trailing space in nack feedback type" do
+      assert RTCPFeedback.parse("* nack ") == {:ok, %RTCPFeedback{pt: :all, feedback_type: :nack}}
+    end
+
     test "unknown feedback type" do
       assert RTCPFeedback.parse("96 unknown") ==
                {:ok, %RTCPFeedback{pt: 96, feedback_type: "unknown"}}


### PR DESCRIPTION
This PR makes SDP parsing more tolerant for rtcp-fb lines with a trailing space (e.g. a=rtcp-fb:<pt> nack ).
Motivation is that WebRTC.rs's SDP formatting of RTCP feedback can produce trailing spaces form when the feedback parameter is empty(eg. in generic nack attribute), leaving a trailing whitespace delimiter which causes negotation issues between ex_webrtc and webrtc.rs.